### PR TITLE
chore: prepare Dart 3.12 and OpenTelemetry 0.10 release train

### DIFF
--- a/.github/workflows/aggregate.yaml
+++ b/.github/workflows/aggregate.yaml
@@ -50,7 +50,10 @@ jobs:
         with:
           name: devenv
       - name: Install devenv
-        run: nix profile install nixpkgs#devenv
+        # Keep the CLI aligned with the pinned nixpkgs input in devenv.lock.
+        run: >-
+          nix profile install
+          github:NixOS/nixpkgs/a831408e6378bc02ebf8cc09b52c96ca86f6bab4#devenv
       - name: Run the centralized workspace gate
         run: >-
           devenv shell

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -87,11 +87,12 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            # Keep pull-request runs useful without spending the entire job
-            # timeout on 36 sequential external-store trials. Scheduled and
-            # manually dispatched runs retain the larger statistical sweep.
-            tasks=250
-            warmup=25
+            # External-store pull-request runs are functional smoke reports,
+            # not performance baselines. Keep them short enough to cover both
+            # runtimes, stores, and buckets; scheduled and manually dispatched
+            # runs retain the larger statistical sweep.
+            tasks=25
+            warmup=5
             buckets=1,4
             samples=1
           else

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -51,7 +51,10 @@ jobs:
         with:
           name: devenv
       - name: Install devenv
-        run: nix profile install nixpkgs#devenv
+        # Keep the CLI aligned with the pinned nixpkgs input in devenv.lock.
+        run: >-
+          nix profile install
+          github:NixOS/nixpkgs/a831408e6378bc02ebf8cc09b52c96ca86f6bab4#devenv
       - name: Start benchmark services
         run: devenv up -d
       - name: Wait for benchmark services
@@ -69,6 +72,7 @@ jobs:
             --check-baseline \
             --output .tmp/ci-benchmarks/memory-aot.json
       - name: Run JIT memory throughput report
+        if: always()
         run: |
           devenv shell -- stem-benchmark-jit \
             --store memory \
@@ -78,6 +82,7 @@ jobs:
             --samples 3 \
             --output .tmp/ci-benchmarks/memory-jit.json
       - name: Run external-store throughput reports
+        if: always()
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -87,10 +87,13 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            tasks=500
-            warmup=50
+            # Keep pull-request runs useful without spending the entire job
+            # timeout on 36 sequential external-store trials. Scheduled and
+            # manually dispatched runs retain the larger statistical sweep.
+            tasks=250
+            warmup=25
             buckets=1,4
-            samples=3
+            samples=1
           else
             tasks="$STORE_TASKS_INPUT"
             warmup="$STORE_WARMUP_INPUT"

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -9,8 +9,9 @@ jobs:
   health:
     uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
     with:
-      # Stem contains Flutter packages alongside its Dart packages.
-      use-flutter: true
+      # PR Health uses this list to run Flutter tooling for the packages that
+      # depend on the Flutter SDK.
+      flutter_packages: packages/stem_flutter,packages/stem_flutter_sqlite
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -1,0 +1,16 @@
+name: Health
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+
+jobs:
+  health:
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    with:
+      # Stem contains Flutter packages alongside its Dart packages.
+      use-flutter: true
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   health:
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@b79f68c55d4a611e7ebf63091036f3f18b5d94b3 # v2026-08-25
     with:
       # PR Health uses this list to run Flutter tooling for the packages that
       # depend on the Flutter SDK.

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -1,0 +1,17 @@
+name: Comment on the pull request
+
+on:
+  # workflow_run executes in the base repository context, which gives this
+  # small trusted workflow permission to update PRs from forks safely.
+  workflow_run:
+    workflows:
+      - Health
+      - Publish
+    types:
+      - completed
+
+jobs:
+  upload:
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    permissions:
+      pull-requests: write

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -12,6 +12,6 @@ on:
 
 jobs:
   upload:
-    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@b79f68c55d4a611e7ebf63091036f3f18b5d94b3 # v2026-08-25
     permissions:
       pull-requests: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,9 @@ jobs:
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
     with:
       use-flutter: true
+      # Let post_summaries.yaml publish comments from the trusted workflow_run
+      # context, including for pull requests opened from forks.
+      write-comments: false
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,11 @@
 name: Publish
 
-# Pull requests and release tags run Stem's repository-owned release gate.
-# Tags then continue through Dart's trusted publishing workflow.
+permissions:
+  contents: read
+
+# Firehose validates package publication metadata on pull requests and
+# publishes the selected package for versioned tags. The workspace test suite
+# belongs to aggregate CI, not this publication/comment workflow.
 on:
   pull_request:
     branches: [ master ]
@@ -10,37 +14,19 @@ on:
     # For mono repos the tag must be prefixed with the package name,
     # e.g. "stem-v0.3.0". Every published package uses this form.
     tags:
-      - '[A-Za-z0-9_]+-v[0-9]+.[0-9]+.[0-9]+'
+      # GitHub tag filters are globs, not regular expressions. Firehose
+      # validates the package prefix and complete semantic version.
+      - '*-v*.*.*'
   workflow_dispatch:
 
 jobs:
-  release-gate:
-    name: release gate
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: 3.10.0
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          cache: true
-      - name: Resolve workspace dependencies
-        run: dart pub get
-      - name: Validate the complete release train
-        run: dart run tool/publish.dart --skip-published --include-unchanged
-
   publish:
-    needs: release-gate
-    if: startsWith(github.ref, 'refs/tags/') && needs.release-gate.result == 'success'
     # This job uses the common publish workflow provided by the ecosystem.
     # See https://github.com/dart-lang/ecosystem/wiki/Publishing-automation
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
     with:
       use-flutter: true
     permissions:
+      contents: read
       id-token: write
       pull-requests: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
   publish:
     # This job uses the common publish workflow provided by the ecosystem.
     # See https://github.com/dart-lang/ecosystem/wiki/Publishing-automation
-    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@b79f68c55d4a611e7ebf63091036f3f18b5d94b3 # v2026-08-25
     with:
       use-flutter: true
       # Let post_summaries.yaml publish comments from the trusted workflow_run

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ stem health
 
 ### Prerequisites
 
-- Dart 3.10.0+
+- Dart 3.12.0+
 - Flutter 3.47.0+ (for the local Flutter package gate)
 - Docker (for adapter integration tests)
 - Nix and devenv 2.2+ (recommended workspace environment)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -99,9 +99,10 @@ devenv shell -- repodoc benchmark:throughput \
 ```
 
 Use `--json` when a command or script needs the raw result on stdout. Repodoc
-owns the benchmark implementation and is the only supported throughput entry
-point. Adapter benchmarks should live beside the adapter because Redis,
-Postgres and SQLite contention have different costs.
+owns the repository-wide throughput benchmark entry point. Adapter packages
+may also provide separate adapter-specific throughput benchmarks beside their
+implementation because Redis, Postgres and SQLite contention have different
+costs.
 
 GitHub CI runs the memory benchmark as a hard regression gate and runs SQLite,
 PostgreSQL, and Redis sequentially as external-store smoke/report benchmarks.

--- a/benchmark/benchmark_display.dart
+++ b/benchmark/benchmark_display.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:artisanal/artisanal.dart';
 
-import '../repodoc/lib/src/benchmarks/formatting.dart';
+import 'benchmark_formatting.dart';
 
 void displayThroughputResult(
   Map<String, Object?> result, {

--- a/benchmark/benchmark_formatting.dart
+++ b/benchmark/benchmark_formatting.dart
@@ -1,0 +1,12 @@
+/// Converts a dynamic benchmark value to a numeric value when possible.
+num? benchmarkNumber(Object? value) => value is num ? value : null;
+
+/// Formats a benchmark number using compact, stable decimal thresholds.
+String benchmarkFixed(Object? value) {
+  final number = benchmarkNumber(value);
+  if (number == null) return 'n/a';
+  if (number.abs() >= 1000000) return number.toStringAsFixed(0);
+  if (number.abs() >= 1000) return number.toStringAsFixed(1);
+  if (number.abs() >= 1) return number.toStringAsFixed(2);
+  return number.toStringAsFixed(3);
+}

--- a/benchmark/profile_support.dart
+++ b/benchmark/profile_support.dart
@@ -1,0 +1,18 @@
+double profilePercentile(List<double> sorted, double percentile) {
+  final index = ((sorted.length - 1) * percentile).round();
+  return sorted[index.clamp(0, sorted.length - 1).toInt()];
+}
+
+String? profileStringOption(List<String> args, String name) {
+  final prefix = '$name=';
+  for (final arg in args) {
+    if (arg.startsWith(prefix)) return arg.substring(prefix.length);
+  }
+  final index = args.indexOf(name);
+  if (index == -1 || index + 1 >= args.length) return null;
+  return args[index + 1];
+}
+
+int profileIntOption(List<String> args, String name, int fallback) {
+  return int.tryParse(profileStringOption(args, name) ?? '') ?? fallback;
+}

--- a/benchmark/stem_job_profile.dart
+++ b/benchmark/stem_job_profile.dart
@@ -6,6 +6,8 @@ import 'package:crypto/crypto.dart';
 import 'package:stem/memory.dart';
 import 'package:stem/stem.dart';
 
+import 'profile_support.dart';
+
 /// Runs one deterministic worker-job profile.
 ///
 /// This workload is deliberately separate from the throughput regression
@@ -91,7 +93,7 @@ Future<void> main(List<String> args) async {
     };
 
     final encoded = jsonEncode(result);
-    final output = _stringOption(args, '--output');
+    final output = profileStringOption(args, '--output');
     if (output != null) {
       final file = File(output);
       await file.parent.create(recursive: true);
@@ -274,30 +276,11 @@ Map<String, Object?> _timingStats(Iterable<double?> values) {
   return {
     'count': sorted.length,
     'min': sorted.first,
-    'median': _percentile(sorted, 0.5),
-    'p95': _percentile(sorted, 0.95),
+    'median': profilePercentile(sorted, 0.5),
+    'p95': profilePercentile(sorted, 0.95),
     'max': sorted.last,
     'mean': sum / sorted.length,
   };
-}
-
-double _percentile(List<double> sorted, double percentile) {
-  final index = ((sorted.length - 1) * percentile).round();
-  return sorted[index.clamp(0, sorted.length - 1).toInt()];
-}
-
-String? _stringOption(List<String> args, String name) {
-  final prefix = '$name=';
-  for (final arg in args) {
-    if (arg.startsWith(prefix)) return arg.substring(prefix.length);
-  }
-  final index = args.indexOf(name);
-  if (index == -1 || index + 1 >= args.length) return null;
-  return args[index + 1];
-}
-
-int _intOption(List<String> args, String name, int fallback) {
-  return int.tryParse(_stringOption(args, name) ?? '') ?? fallback;
 }
 
 void _printUsage() {
@@ -309,11 +292,11 @@ Runs a deterministic in-memory worker workload and emits one JSON sample.
 Options:
   --tasks <n>              Measured task count (default: 5000)
   --warmup <n>             Warmup task count (default: 500)
-  --concurrency <n>       Worker concurrency (default: 4)
-  --mode inline|isolate   Handler execution mode (default: isolate)
-  --workload noop|cpu     Handler workload (default: noop)
-  --work-units <n>        CPU hash rounds per task (default: 100)
-  --hold-seconds <n>      Keep the VM alive after output (default: 0)
+  --concurrency <n>        Worker concurrency (default: 4)
+  --mode inline|isolate    Handler execution mode (default: isolate)
+  --workload noop|cpu      Handler workload (default: noop)
+  --work-units <n>         CPU hash rounds per task (default: 100)
+  --hold-seconds <n>       Keep the VM alive after output (default: 0)
   --output <path>          Also write JSON to this file
 ''');
 }
@@ -339,13 +322,13 @@ final class _ProfileConfig {
   });
 
   factory _ProfileConfig.fromArgs(List<String> args) {
-    final tasks = _intOption(args, '--tasks', 5000);
-    final warmup = _intOption(args, '--warmup', 500);
-    final concurrency = _intOption(args, '--concurrency', 4);
-    final workUnits = _intOption(args, '--work-units', 100);
-    final holdSeconds = _intOption(args, '--hold-seconds', 0);
-    final mode = _stringOption(args, '--mode') ?? 'isolate';
-    final workload = _stringOption(args, '--workload') ?? 'noop';
+    final tasks = profileIntOption(args, '--tasks', 5000);
+    final warmup = profileIntOption(args, '--warmup', 500);
+    final concurrency = profileIntOption(args, '--concurrency', 4);
+    final workUnits = profileIntOption(args, '--work-units', 100);
+    final holdSeconds = profileIntOption(args, '--hold-seconds', 0);
+    final mode = profileStringOption(args, '--mode') ?? 'isolate';
+    final workload = profileStringOption(args, '--workload') ?? 'noop';
 
     if (tasks <= 0 || warmup < 0 || concurrency <= 0 || workUnits < 0) {
       throw ArgumentError(
@@ -357,12 +340,14 @@ final class _ProfileConfig {
       throw ArgumentError.value(holdSeconds, '--hold-seconds');
     }
 
+    final resolvedMode = _parseExecutionMode(mode);
+    final resolvedWorkload = _parseWorkload(workload);
     return _ProfileConfig(
       tasks: tasks,
       warmup: warmup,
       concurrency: concurrency,
-      mode: TaskExecutionMode.values.byName(mode),
-      workload: _ProfileWorkload.values.byName(workload),
+      mode: resolvedMode,
+      workload: resolvedWorkload,
       workUnits: workUnits,
       holdSeconds: holdSeconds,
     );
@@ -375,4 +360,24 @@ final class _ProfileConfig {
   final _ProfileWorkload workload;
   final int workUnits;
   final int holdSeconds;
+
+  static TaskExecutionMode _parseExecutionMode(String value) {
+    for (final mode in TaskExecutionMode.values) {
+      if (mode.name == value) return mode;
+    }
+    throw ArgumentError(
+      'Invalid --mode "$value". Expected one of: '
+      '${TaskExecutionMode.values.map((mode) => mode.name).join(', ')}.',
+    );
+  }
+
+  static _ProfileWorkload _parseWorkload(String value) {
+    for (final workload in _ProfileWorkload.values) {
+      if (workload.name == value) return workload;
+    }
+    throw ArgumentError(
+      'Invalid --workload "$value". Expected one of: '
+      '${_ProfileWorkload.values.map((workload) => workload.name).join(', ')}.',
+    );
+  }
 }

--- a/devenv.nix
+++ b/devenv.nix
@@ -49,7 +49,9 @@
 
       if [ ! -x "$binary" ]; then
         rebuild=true
-      elif [ -n "$(find "$repo_root/repodoc/bin" "$repo_root/repodoc/lib" "$repo_root/packages" -type f -newer "$binary" -print -quit)" ]; then
+      elif [ -n "$(find "$repo_root/repodoc/bin" "$repo_root/repodoc/lib" "$repo_root/packages" \
+        -type f \( -name '*.dart' -o -name 'pubspec.yaml' \) \
+        -newer "$binary" -print -quit)" ]; then
         rebuild=true
       else
         for dependency_file in \

--- a/packages/dashboard/CHANGELOG.md
+++ b/packages/dashboard/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+- Raised the minimum Dart SDK to 3.12.0 and the Ormed dependency to 0.3.0.
+
 ## 0.1.0
 
 - Updated the dashboard data layer to use Ormed 0.2.0.

--- a/packages/dashboard/pubspec.yaml
+++ b/packages/dashboard/pubspec.yaml
@@ -3,7 +3,7 @@ description: Hotwire + Routed dashboard for the Stem runtime.
 version: 0.1.0
 publish_to: "none"
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   intl: ^0.20.2

--- a/packages/dashboard/pubspec.yaml
+++ b/packages/dashboard/pubspec.yaml
@@ -1,22 +1,22 @@
 name: stem_dashboard
 description: Hotwire + Routed dashboard for the Stem runtime.
-version: 0.1.0
+version: 0.2.0
 publish_to: "none"
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   intl: ^0.20.2
   meta: ^1.18.0
-  ormed: ^0.2.0
+  ormed: ">=0.3.0 <1.0.0"
   routed: ^0.5.0
   routed_hotwire: ^0.1.5
   stem:
     path: ../stem
-  stem_cli: ^0.2.0
-  stem_postgres: ^0.2.0
-  stem_redis: ^0.2.0
-  stem_sqlite: ^0.2.0
+  stem_cli: ^0.3.0
+  stem_postgres: ^0.3.0
+  stem_redis: ^0.3.0
+  stem_sqlite: ^0.3.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/stem/CHANGELOG.md
+++ b/packages/stem/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Raised the ecommerce example's minimum Dart SDK to 3.10.0.
+
 ## 0.3.0
 
 - Promoted the typed stable/advanced API boundary and removed implicit worker

--- a/packages/stem/CHANGELOG.md
+++ b/packages/stem/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Unreleased
 
-- Raised the ecommerce example's minimum Dart SDK to 3.10.0.
+## 0.4.0
+
+- Raised the minimum Dart SDK to 3.12.0 for the coordinated Ormed 0.3
+  release train.
+- Raised the ecommerce example's minimum Dart SDK to 3.12.0.
+- Upgraded Dartastic OpenTelemetry to 0.10.0 and its API to 0.10.0. Stem now
+  benefits from zone-safe context propagation, sampler-correct spans, global
+  propagator configuration, and the SDK's no-processor fast path.
+- This release intentionally contains breaking dependency and SDK changes
+  from the 0.3 line.
 
 ## 0.3.0
 

--- a/packages/stem/CHANGELOG.md
+++ b/packages/stem/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## Unreleased
-
 ## 0.4.0
 
 - Raised the minimum Dart SDK to 3.12.0 for the coordinated Ormed 0.3

--- a/packages/stem/README.md
+++ b/packages/stem/README.md
@@ -3,7 +3,7 @@
 </p>
 
 [![pub package](https://img.shields.io/pub/v/stem.svg)](https://pub.dev/packages/stem)
-[![Dart](https://img.shields.io/badge/dart-%3E%3D3.9.2-blue.svg)](https://dart.dev/)
+[![Dart](https://img.shields.io/badge/dart-%3E%3D3.12-blue.svg)](https://dart.dev/)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow.svg)](https://www.buymeacoffee.com/kingwill101)
 

--- a/packages/stem/doc/internal/deployment/release-process.md
+++ b/packages/stem/doc/internal/deployment/release-process.md
@@ -43,7 +43,7 @@ This guide covers preparation, versioning, and post-release steps for Stem.
    runs in dependency order.
 3. Commit exactly the metadata used for the release.
 4. Tag each package independently using `<package>-v<version>`, for example
-   `stem-v0.3.0` or `stem_flutter-v0.2.0`, then push the tags. The trusted
+   `stem-v0.4.0` or `stem_flutter-v0.3.0`, then push the tags. The trusted
    publishing workflow consumes these tags and publishes the matching package.
 5. Verify the package pages and dependency resolution after publication.
 

--- a/packages/stem/doc/internal/operations/operations-guide.md
+++ b/packages/stem/doc/internal/operations/operations-guide.md
@@ -24,6 +24,7 @@ Stem reads configuration from environment variables. The most common settings ar
 | `STEM_REVOKE_STORE_URL` | Override the persistent revoke store (defaults to backend/broker) |
 | `STEM_METRIC_EXPORTERS` | Comma separated exporters (`console`, `otlp:http://host:4318/v1/metrics`, `prometheus`) |
 | `STEM_OTLP_ENDPOINT` | Default OTLP HTTP endpoint used when exporters omit a target |
+| `OTEL_PROPAGATORS` | OpenTelemetry context propagators (`tracecontext,baggage` by default, or `none`) |
 | `STEM_SIGNING_KEYS` / `STEM_SIGNING_ACTIVE_KEY` | HMAC signing secrets and active key identifier |
 | `STEM_SIGNING_PUBLIC_KEYS` / `STEM_SIGNING_PRIVATE_KEYS` | Ed25519 verification & signing material |
 | `STEM_SIGNING_ALGORITHM` | `hmac-sha256` (default) or `ed25519` |
@@ -88,7 +89,10 @@ Stem emits metrics and heartbeats via the observability module:
 - **Histograms**: task execution latency.
 - **Gauges**: active isolates, in-flight deliveries, per-queue depth.
 
-Plumb OpenTelemetry exporters into your APM of choice. The CLI command `stem worker status --follow` subscribes to heartbeat streams for live debugging.
+Plumb OpenTelemetry exporters into your APM of choice. Stem uses the OpenTelemetry
+global text-map propagator for task headers, so `OTEL_PROPAGATORS` can select the
+propagation set without a Stem-specific configuration layer. The CLI command
+`stem worker status --follow` subscribes to heartbeat streams for live debugging.
 
 Use `stem worker status --once` to dump the latest snapshot from the result backend, or `stem worker status --follow --timeout 60s` to stream updates with a timeout guard. Override connection targets with `--backend` / `--broker`, and adjust expectations with `--heartbeat-interval`.
 

--- a/packages/stem/doc/internal/operations/stem-dashboard.md
+++ b/packages/stem/doc/internal/operations/stem-dashboard.md
@@ -20,7 +20,7 @@ the routed ecosystem overrides, and validate the control-plane features.
   - Redis: `redis://127.0.0.1:6379/0`
   - Postgres: `postgres://user:pass@localhost:5432/stem`
   - In-memory: `memory://` (good for unit/integration tests)
-- Dart SDK ≥ 3.9.2.
+- Dart SDK ≥ 3.12.0.
 
 ## Environment
 

--- a/packages/stem/example/annotated_workflows/pubspec.yaml
+++ b/packages/stem/example/annotated_workflows/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   stem:

--- a/packages/stem/example/autoscaling_demo/pubspec.yaml
+++ b/packages/stem/example/autoscaling_demo/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates worker autoscaling decisions under queue backlog.
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/dlq_sandbox/pubspec.yaml
+++ b/packages/stem/example/dlq_sandbox/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates Stem dead-letter queue inspection and replay workflows
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/docs_snippets/pubspec.yaml
+++ b/packages/stem/example/docs_snippets/pubspec.yaml
@@ -2,7 +2,7 @@ name: stem_examples
 description: Runnable code examples for Stem documentation
 publish_to: none
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   stem:

--- a/packages/stem/example/ecommerce/pubspec.yaml
+++ b/packages/stem/example/ecommerce/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   ormed: ^0.2.0
-  ormed_sqlite: ">=0.2.0 <0.4.0"
+  ormed_sqlite: ">=0.2.0 <1.0.0"
   path: ^1.9.1
   shelf: ^1.4.2
   shelf_router: ^1.1.4

--- a/packages/stem/example/ecommerce/pubspec.yaml
+++ b/packages/stem/example/ecommerce/pubspec.yaml
@@ -4,11 +4,11 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
-  ormed: ^0.2.0
-  ormed_sqlite: ">=0.2.0 <1.0.0"
+  ormed: ">=0.3.0 <1.0.0"
+  ormed_sqlite: ">=0.4.0 <1.0.0"
   path: ^1.9.1
   shelf: ^1.4.2
   shelf_router: ^1.1.4

--- a/packages/stem/example/ecommerce/pubspec.yaml
+++ b/packages/stem/example/ecommerce/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   ormed: ^0.2.0
-  ormed_sqlite: ^0.3.0
+  ormed_sqlite: ">=0.2.0 <0.4.0"
   path: ^1.9.1
   shelf: ^1.4.2
   shelf_router: ^1.1.4

--- a/packages/stem/example/ecommerce/pubspec.yaml
+++ b/packages/stem/example/ecommerce/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   ormed: ^0.2.0

--- a/packages/stem/example/email_service/README.md
+++ b/packages/stem/example/email_service/README.md
@@ -5,7 +5,7 @@ This example demonstrates a real-world email notification service using Stem. It
 ## Prerequisites
 
 - Docker and Docker Compose
-- Dart 3.3+ (optional, only required for local execution)
+- Dart 3.12+ (optional, only required for local execution)
 
 ## Configuration
 

--- a/packages/stem/example/email_service/pubspec.yaml
+++ b/packages/stem/example/email_service/pubspec.yaml
@@ -3,7 +3,7 @@ description: Email notification service example using Stem task queue.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   shelf: ^1.4.1

--- a/packages/stem/example/encrypted_payload/enqueuer/pubspec.yaml
+++ b/packages/stem/example/encrypted_payload/enqueuer/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 description: Enqueues encrypted payloads before handing them to Stem.
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   cryptography: ^2.5.0

--- a/packages/stem/example/encrypted_payload/worker/pubspec.yaml
+++ b/packages/stem/example/encrypted_payload/worker/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 description: Worker that decrypts payloads after pulling from the broker.
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   cryptography: ^2.5.0

--- a/packages/stem/example/flutter_stem_example/pubspec.yaml
+++ b/packages/stem/example/flutter_stem_example/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/packages/stem/example/image_processor/README.md
+++ b/packages/stem/example/image_processor/README.md
@@ -13,7 +13,7 @@ This example demonstrates image thumbnail generation using Stem. It enqueues ima
 ## Prerequisites
 
 - Docker and Docker Compose
-- Dart 3.3+ (optional, only required for manual runs)
+- Dart 3.12+ (optional, only required for manual runs)
 
 ## Configuration
 

--- a/packages/stem/example/image_processor/pubspec.yaml
+++ b/packages/stem/example/image_processor/pubspec.yaml
@@ -3,7 +3,7 @@ description: Image thumbnail generation example using Stem task queue.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   shelf: ^1.4.1

--- a/packages/stem/example/microservice/README.md
+++ b/packages/stem/example/microservice/README.md
@@ -5,7 +5,7 @@ This example splits the enqueue API, worker fleet, and beat scheduler into separ
 ## Prerequisites
 
 - Docker and Docker Compose
-- Dart 3.3+ (optional, only needed for running directly on your machine)
+- Dart 3.12+ (optional, only needed for running directly on your machine)
 
 ## Configuration
 

--- a/packages/stem/example/microservice/beat/pubspec.yaml
+++ b/packages/stem/example/microservice/beat/pubspec.yaml
@@ -3,7 +3,7 @@ description: Beat scheduler for the Stem microservice example.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   yaml: ^3.1.2

--- a/packages/stem/example/microservice/enqueuer/pubspec.yaml
+++ b/packages/stem/example/microservice/enqueuer/pubspec.yaml
@@ -3,7 +3,7 @@ description: HTTP API that enqueues Stem tasks using Redis.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   shelf: ^1.4.1

--- a/packages/stem/example/microservice/worker/pubspec.yaml
+++ b/packages/stem/example/microservice/worker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Dedicated worker process consuming Stem tasks via Redis.
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/mixed_cluster/enqueuer/pubspec.yaml
+++ b/packages/stem/example/mixed_cluster/enqueuer/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 description: Enqueuer that targets Redis and Postgres workers.
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/mixed_cluster/postgres_worker/pubspec.yaml
+++ b/packages/stem/example/mixed_cluster/postgres_worker/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 description: Worker that consumes from Postgres broker and stores results in Postgres.
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/mixed_cluster/redis_worker/pubspec.yaml
+++ b/packages/stem/example/mixed_cluster/redis_worker/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 description: Worker that consumes from Redis and stores results in Redis.
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/monolith_service/pubspec.yaml
+++ b/packages/stem/example/monolith_service/pubspec.yaml
@@ -3,7 +3,7 @@ description: Simple monolithic Stem deployment with in-memory adapters.
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   shelf: ^1.4.1

--- a/packages/stem/example/ops_health_suite/pubspec.yaml
+++ b/packages/stem/example/ops_health_suite/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates CLI health checks, heartbeats, and queue snapshots.
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/otel_metrics/pubspec.yaml
+++ b/packages/stem/example/otel_metrics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Minimal example streaming Stem metrics to an OpenTelemetry collecto
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/postgres_tls/README.md
+++ b/packages/stem/example/postgres_tls/README.md
@@ -8,7 +8,7 @@ can be reused across brokers and backends.
 ## Prerequisites
 
 - Docker (for the bundled Postgres + Redis services)
-- Dart 3.9 or newer (`dart --version`)
+- Dart 3.12 or newer (`dart --version`)
 
 ## Run the demo
 

--- a/packages/stem/example/postgres_worker/enqueuer/pubspec.yaml
+++ b/packages/stem/example/postgres_worker/enqueuer/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 description: Example enqueuer that uses Postgres for broker and result backend.
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/postgres_worker/worker/pubspec.yaml
+++ b/packages/stem/example/postgres_worker/worker/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 description: Worker process backed by Postgres broker and result backend.
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/progress_heartbeat/pubspec.yaml
+++ b/packages/stem/example/progress_heartbeat/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates task progress and heartbeat reporting patterns.
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/rate_limit_delay/pubspec.yaml
+++ b/packages/stem/example/rate_limit_delay/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates delayed delivery with priority clamping and Redis-back
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/redis_postgres_worker/enqueuer/pubspec.yaml
+++ b/packages/stem/example/redis_postgres_worker/enqueuer/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 description: Enqueuer using Redis broker and Postgres backend.
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/redis_postgres_worker/worker/pubspec.yaml
+++ b/packages/stem/example/redis_postgres_worker/worker/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 description: Worker using Redis broker and Postgres result backend.
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/retry_task/pubspec.yaml
+++ b/packages/stem/example/retry_task/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates Stem retry behavior with a task that fails through all
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/routing_parity/pubspec.yaml
+++ b/packages/stem/example/routing_parity/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates routing priority, broadcast, and multi-queue workers.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   stem:

--- a/packages/stem/example/scheduler_observability/pubspec.yaml
+++ b/packages/stem/example/scheduler_observability/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates Beat scheduler drift metrics and schedule signals.
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/signals_demo/pubspec.yaml
+++ b/packages/stem/example/signals_demo/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates Stem signal hooks with a worker and producer pair.
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/signing_key_rotation/pubspec.yaml
+++ b/packages/stem/example/signing_key_rotation/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates rotating HMAC signing keys with overlap.
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/example/task_context_mixed/README.md
+++ b/packages/stem/example/task_context_mixed/README.md
@@ -10,7 +10,7 @@ enqueueing, progress reporting, workflow/event calls, and retry requests.
 
 ## Requirements
 
-- Dart 3.3+
+- Dart 3.12+
 
 ## Run
 

--- a/packages/stem/example/task_context_mixed/pubspec.yaml
+++ b/packages/stem/example/task_context_mixed/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates TaskContext and TaskInvocationContext enqueue patterns
 publish_to: "none"
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   stem:

--- a/packages/stem/example/worker_control_lab/pubspec.yaml
+++ b/packages/stem/example/worker_control_lab/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates worker control commands (ping, stats, revoke, shutdown
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   stem:

--- a/packages/stem/lib/src/observability/tracing.dart
+++ b/packages/stem/lib/src/observability/tracing.dart
@@ -16,7 +16,7 @@ class StemTracer {
 
   bool get _isTelemetryReady => dotel_api.OTelFactory.otelFactory != null;
 
-  dotel_api.Context _fallbackContext() => dotel_api.ContextCreate.create();
+  dotel_api.Context _fallbackContext() => dotel_api.OTelAPI.context();
 
   static dotel_api.APITracer _obtainTracer() {
     try {
@@ -44,11 +44,15 @@ class StemTracer {
     if (!_isTelemetryReady) {
       return fn();
     }
+    final tracer = _tracer;
+    // Dartastic 0.10 exposes the SDK's no-processor fast path through the
+    // tracer. Avoid allocating spans and attribute sets when the application
+    // has intentionally disabled trace processors.
+    if (!tracer.enabled) return fn();
     final attributeSet = attributes.isEmpty
         ? null
         : dotel.Attributes.of(Map<String, Object>.from(attributes));
     final baseContext = context ?? dotel.Context.current;
-    final tracer = _tracer;
     final span = tracer.startSpan(
       name,
       context: baseContext,
@@ -75,11 +79,12 @@ class StemTracer {
     if (!_isTelemetryReady) {
       return fn();
     }
+    final tracer = _tracer;
+    if (!tracer.enabled) return fn();
     final attributeSet = attributes.isEmpty
         ? null
         : dotel.Attributes.of(Map<String, Object>.from(attributes));
     final baseContext = context ?? dotel.Context.current;
-    final tracer = _tracer;
     final span = tracer.startSpan(
       name,
       context: baseContext,
@@ -100,11 +105,18 @@ class StemTracer {
     dotel.Context? context,
   }) {
     if (!_isTelemetryReady) return;
-    final spanContext = _spanContextFrom(context ?? dotel.Context.current);
+    final baseContext = context ?? dotel.Context.current;
+    _globalPropagator?.inject(
+      baseContext,
+      headers,
+      _StringMapSetter(headers),
+    );
+    if (_propagationDisabled) return;
+    final spanContext = _spanContextFrom(baseContext);
     if (spanContext == null) return;
 
     final traceParent = _formatTraceparent(spanContext);
-    if (traceParent == null) return;
+    if (traceParent == null || headers['traceparent'] != null) return;
 
     headers['traceparent'] = traceParent;
 
@@ -164,6 +176,15 @@ class StemTracer {
     // Using ambient context here can accidentally chain unrelated async
     // deliveries into one long trace when headers are missing traceparent.
     final baseContext = context ?? _fallbackContext();
+    final propagated = _globalPropagator?.extract(
+      baseContext,
+      headers,
+      _StringMapGetter(headers),
+    );
+    if (_propagationDisabled) return baseContext;
+    if (propagated != null && _spanContextFrom(propagated) != null) {
+      return propagated;
+    }
     final spanContext = _parseTraceContext(headers);
     if (spanContext == null) return baseContext;
     return baseContext.withSpanContext(spanContext);
@@ -203,6 +224,24 @@ class StemTracer {
       return spanContext;
     }
     return null;
+  }
+
+  dotel_api.TextMapPropagator<dynamic, String>? get _globalPropagator {
+    try {
+      final propagator = dotel_api.OTelAPI.textMapPropagator;
+      if (propagator.fields().isEmpty) return null;
+      return propagator as dotel_api.TextMapPropagator<dynamic, String>;
+    } on Object {
+      return null;
+    }
+  }
+
+  bool get _propagationDisabled {
+    try {
+      return dotel.OTelEnv.getPropagators().contains('none');
+    } on Object {
+      return false;
+    }
   }
 
   String? _formatTraceparent(dotel.SpanContext spanContext) {
@@ -251,4 +290,25 @@ class StemTracer {
       return null;
     }
   }
+}
+
+final class _StringMapGetter implements dotel_api.TextMapGetter<String> {
+  const _StringMapGetter(this._headers);
+
+  final Map<String, String> _headers;
+
+  @override
+  String? get(String key) => _headers[key];
+
+  @override
+  Iterable<String> keys() => _headers.keys;
+}
+
+final class _StringMapSetter extends dotel_api.TextMapSetter<String> {
+  _StringMapSetter(this._headers);
+
+  final Map<String, String> _headers;
+
+  @override
+  void set(String key, String value) => _headers[key] = value;
 }

--- a/packages/stem/lib/src/observability/tracing.dart
+++ b/packages/stem/lib/src/observability/tracing.dart
@@ -111,7 +111,7 @@ class StemTracer {
       headers,
       _StringMapSetter(headers),
     );
-    if (_propagationDisabled) return;
+    if (!_traceContextPropagationEnabled) return;
     final spanContext = _spanContextFrom(baseContext);
     if (spanContext == null) return;
 
@@ -181,7 +181,7 @@ class StemTracer {
       headers,
       _StringMapGetter(headers),
     );
-    if (_propagationDisabled) return baseContext;
+    if (!_traceContextPropagationEnabled) return baseContext;
     if (propagated != null && _spanContextFrom(propagated) != null) {
       return propagated;
     }
@@ -241,6 +241,17 @@ class StemTracer {
       return dotel.OTelEnv.getPropagators().contains('none');
     } on Object {
       return false;
+    }
+  }
+
+  bool get _traceContextPropagationEnabled {
+    try {
+      final propagators = dotel.OTelEnv.getPropagators();
+      return !_propagationDisabled && propagators.contains('tracecontext');
+    } on Object {
+      // Preserve the legacy fallback if the optional environment integration
+      // is unavailable in a platform implementation.
+      return true;
     }
   }
 
@@ -310,5 +321,11 @@ final class _StringMapSetter extends dotel_api.TextMapSetter<String> {
   final Map<String, String> _headers;
 
   @override
-  void set(String key, String value) => _headers[key] = value;
+  void set(String key, String value) {
+    if ((key == 'traceparent' || key == 'tracestate') &&
+        _headers.containsKey(key)) {
+      return;
+    }
+    _headers[key] = value;
+  }
 }

--- a/packages/stem/pubspec.yaml
+++ b/packages/stem/pubspec.yaml
@@ -1,10 +1,10 @@
 name: stem
 description: "Experimental Dart-native background job platform with Redis Streams, retries, scheduling, observability, and security tooling."
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/kingwill101/stem
 resolution: workspace
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 # Add regular dependencies here.
 dependencies:
@@ -13,8 +13,8 @@ dependencies:
   contextual: ^2.2.0
   crypto: ^3.0.7
   cryptography: ^2.9.0
-  dartastic_opentelemetry: ^0.9.3
-  dartastic_opentelemetry_api: ^0.8.8
+  dartastic_opentelemetry: ^0.10.0
+  dartastic_opentelemetry_api: ^0.10.0
   glob: ^2.1.3
   meta: ^1.18.0
   timezone: ^0.11.0
@@ -29,12 +29,12 @@ dev_dependencies:
   lints: ^6.0.0
   path: ^1.9.1
   property_testing: ^0.3.2
-  stem_adapter_tests: ^0.2.0
-  #  stem_cli: ^0.2.0
-  #  stem_postgres: ^0.2.0
-  #  stem_redis: ^0.2.0
-  #  stem_sqlite: ^0.2.0
-  test: ^1.29.0
+  stem_adapter_tests: ^0.3.0
+  #  stem_cli: ^0.3.0
+  #  stem_postgres: ^0.3.0
+  #  stem_redis: ^0.3.0
+  #  stem_sqlite: ^0.3.0
+  test: ^1.31.2
   very_good_analysis: ^10.0.0
 
 keywords:

--- a/packages/stem/test/unit/tracing/tracing_test.dart
+++ b/packages/stem/test/unit/tracing/tracing_test.dart
@@ -358,4 +358,23 @@ void main() {
       );
     },
   );
+
+  test('preserves existing trace propagation headers during injection', () {
+    final tracer = dotel.OTel.tracerProvider().getTracer('stem-test-header');
+    final span = tracer.startSpan('existing-parent');
+    final context = dotel.Context.current.withSpan(span);
+    const existingTraceparent =
+        '00-11111111111111111111111111111111-2222222222222222-01';
+    const existingTracestate = 'vendor=value';
+    final headers = <String, String>{
+      'traceparent': existingTraceparent,
+      'tracestate': existingTracestate,
+    };
+
+    StemTracer.instance.injectTraceContext(headers, context: context);
+    span.end();
+
+    expect(headers['traceparent'], existingTraceparent);
+    expect(headers['tracestate'], existingTracestate);
+  });
 }

--- a/packages/stem_adapter_tests/CHANGELOG.md
+++ b/packages/stem_adapter_tests/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0
+
+- Updated the shared contract package for the Stem 0.4.0 release train and
+  Dart 3.12 minimum.
+
 ## 0.2.0
 
 - Updated shared adapter contracts for the Stem 0.3.0 capability and lifecycle

--- a/packages/stem_adapter_tests/pubspec.yaml
+++ b/packages/stem_adapter_tests/pubspec.yaml
@@ -1,14 +1,14 @@
 name: stem_adapter_tests
 description: Shared contract test suites for Stem broker and result backend adapters.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/kingwill101/stem
 resolution: workspace
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
-  stem: ">=0.3.0 <0.4.0"
-  test: ^1.29.0
+  stem: ">=0.4.0 <0.5.0"
+  test: ^1.31.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/stem_builder/CHANGELOG.md
+++ b/packages/stem_builder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+- Updated the builder for the Stem 0.4.0 release train and Dart 3.12 minimum.
+
 ## 0.3.0
 
 - Updated generated task adapters and workflow definitions for Stem 0.3.0.

--- a/packages/stem_builder/README.md
+++ b/packages/stem_builder/README.md
@@ -5,7 +5,7 @@
 # stem_builder
 
 [![pub package](https://img.shields.io/pub/v/stem_builder.svg)](https://pub.dev/packages/stem_builder)
-[![Dart](https://img.shields.io/badge/dart-%3E%3D3.9.2-blue.svg)](https://dart.dev)
+[![Dart](https://img.shields.io/badge/dart-%3E%3D3.12-blue.svg)](https://dart.dev)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](https://github.com/kingwill101/stem/blob/main/LICENSE)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow.svg)](https://www.buymeacoffee.com/kingwill101)
 

--- a/packages/stem_builder/example/pubspec.yaml
+++ b/packages/stem_builder/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   stem:

--- a/packages/stem_builder/pubspec.yaml
+++ b/packages/stem_builder/pubspec.yaml
@@ -1,23 +1,23 @@
 name: stem_builder
 description: Build-time registry generator for annotated Stem workflows and tasks.
-version: 0.3.0
+version: 0.4.0
 
 repository: https://github.com/kingwill101/stem
 resolution: workspace
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
-  analyzer: ^10.0.1
+  analyzer: ^14.1.0
   build: ^4.0.4
   dart_style: ^3.1.4
   glob: ^2.1.3
   source_gen: ^4.1.2
-  stem: ">=0.3.0 <0.4.0"
+  stem: ">=0.4.0 <0.5.0"
 
 dev_dependencies:
   build_runner: ^2.10.5
   build_test: any
   lints: ^6.0.0
-  test: ^1.29.0
+  test: ^1.31.2
   very_good_analysis: ^10.0.0

--- a/packages/stem_builder/test/stem_registry_builder_test.dart
+++ b/packages/stem_builder/test/stem_registry_builder_test.dart
@@ -850,7 +850,7 @@ class SignupWorkflow {
             allOf([
               contains('_StemScriptProxy0(script)'),
               contains(
-                ').run((_stemRequireArg(script.params, "email") as String))',
+                '.run((_stemRequireArg(script.params, "email") as String))',
               ),
               contains('_stemRequireArg(script.params, "email") as String'),
               contains('abstract final class StemWorkflowDefinitions'),
@@ -900,7 +900,7 @@ class SignupWorkflow {
             allOf([
               contains('_StemScriptProxy0(script)'),
               contains(
-                ').run(script, (_stemRequireArg(script.params, "email") as '
+                '.run(script, (_stemRequireArg(script.params, "email") as '
                 'String))',
               ),
             ]),
@@ -942,7 +942,7 @@ class SignupWorkflow {
           'stem_builder|lib/workflows.stem.g.dart': decodedMatches(
             allOf([
               contains(
-                ').run(('
+                '.run(('
                 '_stemRequireArg(script.params, "email") as String), '
                 'context: script)',
               ),

--- a/packages/stem_builder/test/stem_registry_builder_test.dart
+++ b/packages/stem_builder/test/stem_registry_builder_test.dart
@@ -550,9 +550,7 @@ class ScriptWithStepsWorkflow {
               ),
               contains('return _script.step<String>('),
               contains('(context) => super.sendEmail(email)'),
-              contains(
-                'run: (script) => _StemScriptProxy0(script).run(script)',
-              ),
+              contains('_StemScriptProxy0(script)'),
             ]),
           ),
         },
@@ -850,9 +848,7 @@ class SignupWorkflow {
         outputs: {
           'stem_builder|lib/workflows.stem.g.dart': decodedMatches(
             allOf([
-              contains(
-                'run: (script) => _StemScriptProxy0(',
-              ),
+              contains('_StemScriptProxy0(script)'),
               contains(
                 ').run((_stemRequireArg(script.params, "email") as String))',
               ),
@@ -902,7 +898,7 @@ class SignupWorkflow {
         outputs: {
           'stem_builder|lib/workflows.stem.g.dart': decodedMatches(
             allOf([
-              contains('run: (script) => _StemScriptProxy0('),
+              contains('_StemScriptProxy0(script)'),
               contains(
                 ').run(script, (_stemRequireArg(script.params, "email") as '
                 'String))',

--- a/packages/stem_builder/test/stem_registry_builder_test.dart
+++ b/packages/stem_builder/test/stem_registry_builder_test.dart
@@ -591,7 +591,10 @@ class ScriptWorkflow {
             allOf([
               contains('class _StemScriptProxy0 extends ScriptWorkflow'),
               contains(
-                'run: (script) => _StemScriptProxy0(',
+                '_StemScriptProxy0(script)',
+              ),
+              contains(
+                '.run((_stemRequireArg(script.params, "email") as String))',
               ),
               contains('_stemRequireArg(script.params, "email") as String'),
             ]),

--- a/packages/stem_cli/CHANGELOG.md
+++ b/packages/stem_cli/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## Unreleased
-
 ## 0.3.0
 
 - Updated the CLI and adapter dependencies for the Stem 0.4.0 release train

--- a/packages/stem_cli/CHANGELOG.md
+++ b/packages/stem_cli/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
-- Raised the minimum Dart SDK to 3.10.0 and hardened Redis TLS integration
-  fixtures so private keys remain owner-only while test containers run as the
-  non-root Redis user.
+## 0.3.0
+
+- Updated the CLI and adapter dependencies for the Stem 0.4.0 release train
+  and Dart 3.12 minimum.
+- Hardened Redis TLS integration fixtures so private keys remain owner-only
+  while test containers run as the non-root Redis user.
 
 ## 0.2.0
 

--- a/packages/stem_cli/CHANGELOG.md
+++ b/packages/stem_cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Raised the minimum Dart SDK to 3.10.0 and hardened Redis TLS integration
+  fixtures so private keys remain owner-only while test containers run as the
+  non-root Redis user.
+
 ## 0.2.0
 
 - Updated CLI adapter dependencies for the Stem 0.3.0 release train.

--- a/packages/stem_cli/README.md
+++ b/packages/stem_cli/README.md
@@ -5,7 +5,7 @@
 # stem_cli
 
 [![pub package](https://img.shields.io/pub/v/stem_cli.svg)](https://pub.dev/packages/stem_cli)
-[![Dart](https://img.shields.io/badge/dart-%3E%3D3.9.2-blue.svg)](https://dart.dev)
+[![Dart](https://img.shields.io/badge/dart-%3E%3D3.12-blue.svg)](https://dart.dev)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](https://github.com/kingwill101/stem/blob/main/LICENSE)
 [![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kingwill101/stem/main/packages/stem_cli/coverage/coverage.json)](https://github.com/kingwill101/stem/actions/workflows/stem_cli.yaml)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow.svg)](https://www.buymeacoffee.com/kingwill101)

--- a/packages/stem_cli/docker/testing/docker-compose.yml
+++ b/packages/stem_cli/docker/testing/docker-compose.yml
@@ -118,6 +118,9 @@ services:
   # Redis with TLS enabled (server-auth only)
   redis_tls:
     image: redis:7-alpine
+    # Disposable test keys remain owner-only on the host; Redis runs as root
+    # in this test container so it can read the bind-mounted key files.
+    user: "0"
     restart: unless-stopped
     container_name: stem-redis-tls-test
     command:
@@ -169,6 +172,9 @@ services:
   # Redis with TLS enabled (client-auth required)
   redis_mtls:
     image: redis:7-alpine
+    # Disposable test keys remain owner-only on the host; Redis runs as root
+    # in this test container so it can read the bind-mounted key files.
+    user: "0"
     restart: unless-stopped
     container_name: stem-redis-mtls-test
     command:

--- a/packages/stem_cli/docker/testing/docker-compose.yml
+++ b/packages/stem_cli/docker/testing/docker-compose.yml
@@ -118,9 +118,10 @@ services:
   # Redis with TLS enabled (server-auth only)
   redis_tls:
     image: redis:7-alpine
-    # Disposable test keys remain owner-only on the host; Redis runs as root
-    # in this test container so it can read the bind-mounted key files.
+    # Start as root only long enough for the entrypoint to copy owner-only
+    # fixture keys into the container, then drop to the redis user.
     user: "0"
+    entrypoint: ["/usr/local/bin/stem-redis-entrypoint.sh"]
     restart: unless-stopped
     container_name: stem-redis-tls-test
     command:
@@ -130,11 +131,11 @@ services:
       - "--tls-port"
       - "6379"
       - "--tls-cert-file"
-      - "/etc/redis/certs/server.crt"
+      - "/tmp/stem-redis-certs/server.crt"
       - "--tls-key-file"
-      - "/etc/redis/certs/server.key"
+      - "/tmp/stem-redis-certs/server.key"
       - "--tls-ca-cert-file"
-      - "/etc/redis/certs/ca.crt"
+      - "/tmp/stem-redis-certs/ca.crt"
       - "--tls-auth-clients"
       - "no"
       - "--loglevel"
@@ -147,6 +148,7 @@ services:
       - "${STEM_TEST_REDIS_TLS_PORT:-56380}:6379"
     volumes:
       - ../../../stem/example/microservice/certs:/etc/redis/certs:ro
+      - ./redis/entrypoint.sh:/usr/local/bin/stem-redis-entrypoint.sh:ro
       - redis-tls-data:/data
     healthcheck:
       test:
@@ -155,7 +157,7 @@ services:
           "redis-cli",
           "--tls",
           "--cacert",
-          "/etc/redis/certs/ca.crt",
+          "/tmp/stem-redis-certs/ca.crt",
           "-p",
           "6379",
           "ping"
@@ -172,9 +174,10 @@ services:
   # Redis with TLS enabled (client-auth required)
   redis_mtls:
     image: redis:7-alpine
-    # Disposable test keys remain owner-only on the host; Redis runs as root
-    # in this test container so it can read the bind-mounted key files.
+    # Start as root only long enough for the entrypoint to copy owner-only
+    # fixture keys into the container, then drop to the redis user.
     user: "0"
+    entrypoint: ["/usr/local/bin/stem-redis-entrypoint.sh"]
     restart: unless-stopped
     container_name: stem-redis-mtls-test
     command:
@@ -184,11 +187,11 @@ services:
       - "--tls-port"
       - "6379"
       - "--tls-cert-file"
-      - "/etc/redis/certs/server.crt"
+      - "/tmp/stem-redis-certs/server.crt"
       - "--tls-key-file"
-      - "/etc/redis/certs/server.key"
+      - "/tmp/stem-redis-certs/server.key"
       - "--tls-ca-cert-file"
-      - "/etc/redis/certs/ca.crt"
+      - "/tmp/stem-redis-certs/ca.crt"
       - "--tls-auth-clients"
       - "yes"
       - "--loglevel"
@@ -201,6 +204,7 @@ services:
       - "${STEM_TEST_REDIS_MTLS_PORT:-56381}:6379"
     volumes:
       - ../../../stem/example/microservice/certs:/etc/redis/certs:ro
+      - ./redis/entrypoint.sh:/usr/local/bin/stem-redis-entrypoint.sh:ro
       - redis-mtls-data:/data
     healthcheck:
       test:
@@ -209,11 +213,11 @@ services:
           "redis-cli",
           "--tls",
           "--cacert",
-          "/etc/redis/certs/ca.crt",
+          "/tmp/stem-redis-certs/ca.crt",
           "--cert",
-          "/etc/redis/certs/client.crt",
+          "/tmp/stem-redis-certs/client.crt",
           "--key",
-          "/etc/redis/certs/client.key",
+          "/tmp/stem-redis-certs/client.key",
           "-p",
           "6379",
           "ping"

--- a/packages/stem_cli/docker/testing/generate_certs.sh
+++ b/packages/stem_cli/docker/testing/generate_certs.sh
@@ -11,6 +11,7 @@ POSTGRES_CERT_DIR="$SCRIPT_DIR/postgres/certs"
 
 redis_assets=(
   "$REDIS_CERT_DIR/ca.crt"
+  "$REDIS_CERT_DIR/ca.key"
   "$REDIS_CERT_DIR/server.crt"
   "$REDIS_CERT_DIR/server.key"
   "$REDIS_CERT_DIR/client.crt"
@@ -63,8 +64,10 @@ chmod 755 "$REDIS_CERT_DIR" "$POSTGRES_CERT_DIR"
 chmod 644 \
   "$REDIS_CERT_DIR/ca.crt" \
   "$REDIS_CERT_DIR/server.crt" \
+  "$REDIS_CERT_DIR/client.crt"
+chmod 600 \
+  "$REDIS_CERT_DIR/ca.key" \
   "$REDIS_CERT_DIR/server.key" \
-  "$REDIS_CERT_DIR/client.crt" \
   "$REDIS_CERT_DIR/client.key"
 
 echo "Disposable Redis and PostgreSQL TLS assets are ready."

--- a/packages/stem_cli/docker/testing/redis/entrypoint.sh
+++ b/packages/stem_cli/docker/testing/redis/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+
+# The host-mounted fixture keys remain owner-only. Copy them into the
+# container's private temporary filesystem so Redis can use them after it
+# drops privileges from the root bootstrap user.
+source_dir=/etc/redis/certs
+runtime_dir=/tmp/stem-redis-certs
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo 'The Redis TLS test entrypoint must start as root.' >&2
+  exit 1
+fi
+
+mkdir -p "$runtime_dir"
+for asset in "$source_dir"/*.crt "$source_dir"/*.key; do
+  if [ -f "$asset" ]; then
+    cp "$asset" "$runtime_dir/"
+  fi
+done
+
+chown redis:redis "$runtime_dir"
+chown redis:redis "$runtime_dir"/*
+chmod 755 "$runtime_dir"
+for asset in "$runtime_dir"/*.crt; do
+  if [ -f "$asset" ]; then
+    chmod 644 "$asset"
+  fi
+done
+for asset in "$runtime_dir"/*.key; do
+  if [ -f "$asset" ]; then
+    chmod 600 "$asset"
+  fi
+done
+
+if [ "$#" -eq 0 ]; then
+  set -- redis-server
+fi
+
+exec /usr/bin/setpriv --reuid redis --regid redis --clear-groups "$@"

--- a/packages/stem_cli/pubspec.yaml
+++ b/packages/stem_cli/pubspec.yaml
@@ -1,17 +1,17 @@
 name: stem_cli
 description: Command-line tooling for Stem that orchestrates Redis and Postgres adapters.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/kingwill101/stem
 resolution: workspace
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   artisanal: ^0.5.0
-  stem: ">=0.3.0 <0.4.0"
-  stem_redis: ^0.2.0
-  stem_postgres: ^0.2.0
-  stem_sqlite: ^0.2.0
+  stem: ">=0.4.0 <0.5.0"
+  stem_redis: ^0.3.0
+  stem_postgres: ^0.3.0
+  stem_sqlite: ^0.3.0
   redis: ^4.0.0
   postgres: ^3.5.9
   async: ^2.13.0
@@ -22,5 +22,5 @@ dependencies:
 dev_dependencies:
   coverage: ^1.15.0
   lints: ^6.0.0
-  test: ^1.29.0
+  test: ^1.31.2
   very_good_analysis: ^10.0.0

--- a/packages/stem_cli/pubspec.yaml
+++ b/packages/stem_cli/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.0
 repository: https://github.com/kingwill101/stem
 resolution: workspace
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   artisanal: ^0.5.0

--- a/packages/stem_flutter/CHANGELOG.md
+++ b/packages/stem_flutter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0
+
+- Updated the Flutter integration for the Stem 0.4.0 release train and Dart
+  3.12 minimum.
+
 ## 0.2.0
 
 - Updated the Flutter integration for Stem 0.3.0 and explicit worker startup.

--- a/packages/stem_flutter/README.md
+++ b/packages/stem_flutter/README.md
@@ -36,7 +36,7 @@ Those decisions are intentionally left to the app and the adapter package.
 
 ```yaml
 dependencies:
-  stem_flutter: ^0.2.0
+  stem_flutter: ^0.3.0
 ```
 
 ## Minimal Usage

--- a/packages/stem_flutter/lib/src/monitor/stem_flutter_queue_monitor.dart
+++ b/packages/stem_flutter/lib/src/monitor/stem_flutter_queue_monitor.dart
@@ -8,21 +8,15 @@ import 'package:stem_flutter/src/runtime/stem_flutter_worker_signal.dart';
 class StemFlutterQueueMonitor {
   /// Creates a queue monitor for a single Stem queue.
   StemFlutterQueueMonitor({
-    required ResultBackend backend,
-    required Broker broker,
-    required String queueName,
-    required String workerId,
-    Duration pollInterval = const Duration(seconds: 1),
+    required this._backend,
+    required this._broker,
+    required this._queueName,
+    required this._workerId,
+    this._pollInterval = const Duration(seconds: 1),
     Duration heartbeatInterval = const Duration(seconds: 2),
-    int limit = 40,
+    this._limit = 40,
     String Function(TaskStatus status)? labelResolver,
-  }) : _backend = backend,
-       _broker = broker,
-       _queueName = queueName,
-       _workerId = workerId,
-       _pollInterval = pollInterval,
-       _heartbeatFreshness = heartbeatInterval * 3,
-       _limit = limit,
+  }) : _heartbeatFreshness = heartbeatInterval * 3,
        _labelResolver =
            labelResolver ??
            ((status) => status.meta['label']?.toString() ?? status.id);

--- a/packages/stem_flutter/lib/src/monitor/stem_flutter_queue_monitor.dart
+++ b/packages/stem_flutter/lib/src/monitor/stem_flutter_queue_monitor.dart
@@ -1,3 +1,7 @@
+// Public constructor names intentionally initialize private implementation
+// fields to preserve the package API.
+// ignore_for_file: prefer_initializing_formals
+
 import 'dart:async';
 
 import 'package:stem/stem.dart';
@@ -8,15 +12,21 @@ import 'package:stem_flutter/src/runtime/stem_flutter_worker_signal.dart';
 class StemFlutterQueueMonitor {
   /// Creates a queue monitor for a single Stem queue.
   StemFlutterQueueMonitor({
-    required this._backend,
-    required this._broker,
-    required this._queueName,
-    required this._workerId,
-    this._pollInterval = const Duration(seconds: 1),
+    required ResultBackend backend,
+    required Broker broker,
+    required String queueName,
+    required String workerId,
+    Duration pollInterval = const Duration(seconds: 1),
     Duration heartbeatInterval = const Duration(seconds: 2),
-    this._limit = 40,
+    int limit = 40,
     String Function(TaskStatus status)? labelResolver,
-  }) : _heartbeatFreshness = heartbeatInterval * 3,
+  }) : _backend = backend,
+       _broker = broker,
+       _queueName = queueName,
+       _workerId = workerId,
+       _pollInterval = pollInterval,
+       _limit = limit,
+       _heartbeatFreshness = heartbeatInterval * 3,
        _labelResolver =
            labelResolver ??
            ((status) => status.meta['label']?.toString() ?? status.id);

--- a/packages/stem_flutter/lib/src/runtime/stem_flutter_worker_host.dart
+++ b/packages/stem_flutter/lib/src/runtime/stem_flutter_worker_host.dart
@@ -9,16 +9,12 @@ import 'package:stem_flutter/src/runtime/stem_flutter_worker_signal.dart';
 /// provides a small control channel for graceful shutdown.
 class StemFlutterWorkerHost {
   StemFlutterWorkerHost._({
-    required Isolate isolate,
-    required ReceivePort messages,
-    required ReceivePort errors,
-    required ReceivePort exit,
-    required StreamController<StemFlutterWorkerSignal> controller,
-  }) : _isolate = isolate,
-       _messages = messages,
-       _errors = errors,
-       _exit = exit,
-       _controller = controller;
+    required this._isolate,
+    required this._messages,
+    required this._errors,
+    required this._exit,
+    required this._controller,
+  });
 
   final Isolate _isolate;
   final ReceivePort _messages;

--- a/packages/stem_flutter/lib/src/runtime/stem_flutter_worker_host.dart
+++ b/packages/stem_flutter/lib/src/runtime/stem_flutter_worker_host.dart
@@ -1,3 +1,7 @@
+// Public constructor names intentionally initialize private implementation
+// fields to preserve the package API.
+// ignore_for_file: prefer_initializing_formals
+
 import 'dart:async';
 import 'dart:isolate';
 
@@ -9,12 +13,16 @@ import 'package:stem_flutter/src/runtime/stem_flutter_worker_signal.dart';
 /// provides a small control channel for graceful shutdown.
 class StemFlutterWorkerHost {
   StemFlutterWorkerHost._({
-    required this._isolate,
-    required this._messages,
-    required this._errors,
-    required this._exit,
-    required this._controller,
-  });
+    required Isolate isolate,
+    required ReceivePort messages,
+    required ReceivePort errors,
+    required ReceivePort exit,
+    required StreamController<StemFlutterWorkerSignal> controller,
+  }) : _isolate = isolate,
+       _messages = messages,
+       _errors = errors,
+       _exit = exit,
+       _controller = controller;
 
   final Isolate _isolate;
   final ReceivePort _messages;

--- a/packages/stem_flutter/pubspec.yaml
+++ b/packages/stem_flutter/pubspec.yaml
@@ -1,17 +1,17 @@
 name: stem_flutter
 description: Flutter integration helpers for mobile-friendly Stem runtimes.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/kingwill101/stem/tree/master/packages/stem_flutter
 issue_tracker: https://github.com/kingwill101/stem/issues
 resolution: workspace
 
 environment:
-  sdk: ^3.9.2
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  stem: ">=0.3.0 <0.4.0"
+  stem: ">=0.4.0 <0.5.0"
   time_machine2: ^0.13.1
 
 dev_dependencies:

--- a/packages/stem_flutter_sqlite/CHANGELOG.md
+++ b/packages/stem_flutter_sqlite/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0
+
+- Updated the Flutter SQLite integration for the Stem 0.4.0 adapter line and
+  Dart 3.12 minimum.
+
 ## 0.2.0
 
 - Updated the Flutter SQLite integration for the Stem 0.3.0 adapter line.

--- a/packages/stem_flutter_sqlite/README.md
+++ b/packages/stem_flutter_sqlite/README.md
@@ -18,7 +18,7 @@ with Stem and SQLite.
 
 ```yaml
 dependencies:
-  stem_flutter_sqlite: ^0.2.0
+  stem_flutter_sqlite: ^0.3.0
 ```
 
 `stem_flutter_sqlite` depends on `stem_flutter`, `stem_sqlite`, and

--- a/packages/stem_flutter_sqlite/pubspec.yaml
+++ b/packages/stem_flutter_sqlite/pubspec.yaml
@@ -1,20 +1,20 @@
 name: stem_flutter_sqlite
 description: SQLite adapter helpers for Flutter-hosted Stem runtimes.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/kingwill101/stem/tree/master/packages/stem_flutter_sqlite
 issue_tracker: https://github.com/kingwill101/stem/issues
 resolution: workspace
 
 environment:
-  sdk: ^3.9.2
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
   path_provider: ^2.1.5
-  stem: ">=0.3.0 <0.4.0"
-  stem_flutter: ">=0.2.0 <0.3.0"
-  stem_sqlite: ">=0.2.0 <0.3.0"
+  stem: ">=0.4.0 <0.5.0"
+  stem_flutter: ">=0.3.0 <0.4.0"
+  stem_sqlite: ">=0.3.0 <0.4.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/stem_memory/CHANGELOG.md
+++ b/packages/stem_memory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0
+
+- Updated the in-memory adapter for the Stem 0.4.0 release train and Dart 3.12
+  minimum.
+
 ## 0.2.0
 
 - Updated the compatibility package for Stem 0.3.0 and the core-owned memory

--- a/packages/stem_memory/pubspec.yaml
+++ b/packages/stem_memory/pubspec.yaml
@@ -1,18 +1,18 @@
 name: stem_memory
 description: In-memory broker, backend, workflow, and scheduler adapters for Stem.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/kingwill101/stem
 resolution: workspace
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   collection: ^1.19.1
-  stem: ">=0.3.0 <0.4.0"
+  stem: ">=0.4.0 <0.5.0"
   uuid: ^4.5.2
 
 dev_dependencies:
   coverage: ^1.15.0
-  stem_adapter_tests: ^0.2.0
-  test: ^1.29.0
+  stem_adapter_tests: ^0.3.0
+  test: ^1.31.2
   very_good_analysis: ^10.0.0

--- a/packages/stem_postgres/CHANGELOG.md
+++ b/packages/stem_postgres/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.2.0
 
 - Datasource logger injection now uses Stem's dependency-neutral `StemLogger`
   facade; the Ormed contextual logger remains an adapter implementation detail.
 - Added conditional terminal-result updates so late completion attempts cannot
   overwrite an existing terminal state.
-
-## 0.2.0
-
 - Updated the Postgres adapter for Stem 0.3.0 and the capability-aware broker
   contract.
 - Added the transactional outbox, distributed rate limiter, migration registry,

--- a/packages/stem_postgres/CHANGELOG.md
+++ b/packages/stem_postgres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.0
+
+- Raised the minimum Dart SDK to 3.12.0 and the Ormed dependencies to 0.3.0.
+- Retained generated model definitions for Stem's internal typed repositories;
+  Ormed's codegen-free database facade remains available for application-side
+  ad-hoc access.
+
 ## 0.2.0
 
 - Datasource logger injection now uses Stem's dependency-neutral `StemLogger`

--- a/packages/stem_postgres/README.md
+++ b/packages/stem_postgres/README.md
@@ -5,7 +5,7 @@
 # stem_postgres
 
 [![pub package](https://img.shields.io/pub/v/stem_postgres.svg)](https://pub.dev/packages/stem_postgres)
-[![Dart](https://img.shields.io/badge/dart-%3E%3D3.9.2-blue.svg)](https://dart.dev)
+[![Dart](https://img.shields.io/badge/dart-%3E%3D3.12-blue.svg)](https://dart.dev)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](https://github.com/kingwill101/stem/blob/main/LICENSE)
 [![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kingwill101/stem/main/packages/stem_postgres/coverage/coverage.json)](https://github.com/kingwill101/stem/actions/workflows/stem_postgres.yaml)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow.svg)](https://www.buymeacoffee.com/kingwill101)

--- a/packages/stem_postgres/lib/src/brokers/postgres_broker.dart
+++ b/packages/stem_postgres/lib/src/brokers/postgres_broker.dart
@@ -24,10 +24,9 @@ class PostgresBroker
     required this.pollInterval,
     this.sweeperInterval = const Duration(seconds: 10),
     this.deadLetterRetention = const Duration(days: 7),
-    PostgresConnections? consumerConnections,
-    PostgresTimingListener? timingListener,
-  }) : _consumerConnections = consumerConnections,
-       _timingListener = timingListener {
+    this._consumerConnections,
+    this._timingListener,
+  }) {
     stemLogger.info(
       'PostgresBroker created (namespace=$namespace)',
       fields: _logContext(),

--- a/packages/stem_postgres/lib/src/connection.dart
+++ b/packages/stem_postgres/lib/src/connection.dart
@@ -15,20 +15,16 @@ class PostgresConnections {
 
   /// Creates a connection wrapper for an initialized data source.
   PostgresConnections._(
-    DataSource dataSource, {
-    required bool ownsDataSource,
-    String? connectionString,
-    String component = 'postgres',
-    PostgresTimingListener? timingListener,
-    PostgresQueryTimingListener? queryTimingListener,
-  }) : _dataSource = dataSource,
-       _ownsDataSource = ownsDataSource,
-       _connectionString = connectionString,
-       _component = component,
-       _timingListener = timingListener,
-       _queryTimingListener = queryTimingListener,
-       _transactionQueueRef = _queuesByDataSource[dataSource] ??=
-           _TransactionQueue();
+    this._dataSource, {
+    required this._ownsDataSource,
+    this._connectionString,
+    this._component = 'postgres',
+    this._timingListener,
+    this._queryTimingListener,
+  }) {
+    _transactionQueueRef = _queuesByDataSource[_dataSource] ??=
+        _TransactionQueue();
+  }
 
   static final Expando<_TransactionQueue> _queuesByDataSource =
       Expando<_TransactionQueue>();
@@ -65,7 +61,7 @@ class PostgresConnections {
   final PostgresTimingListener? _timingListener;
   final PostgresQueryTimingListener? _queryTimingListener;
   void Function()? _removeQueryListener;
-  _TransactionQueue _transactionQueueRef;
+  late final _TransactionQueue _transactionQueueRef;
 
   /// Convenience accessor for the raw ORM connection.
   OrmConnection get connection => _dataSource.connection;

--- a/packages/stem_postgres/lib/src/connection.dart
+++ b/packages/stem_postgres/lib/src/connection.dart
@@ -1,3 +1,7 @@
+// Public constructor names intentionally initialize private implementation
+// fields to preserve the package API.
+// ignore_for_file: prefer_initializing_formals
+
 import 'package:ormed/ormed.dart';
 
 import 'package:stem_postgres/src/database/datasource.dart';
@@ -16,12 +20,12 @@ class PostgresConnections {
   /// Creates a connection wrapper for an initialized data source.
   PostgresConnections._(
     this._dataSource, {
-    required this._ownsDataSource,
+    required bool ownsDataSource,
     this._connectionString,
     this._component = 'postgres',
     this._timingListener,
     this._queryTimingListener,
-  }) {
+  }) : _ownsDataSource = ownsDataSource {
     _transactionQueueRef = _queuesByDataSource[_dataSource] ??=
         _TransactionQueue();
   }
@@ -61,7 +65,7 @@ class PostgresConnections {
   final PostgresTimingListener? _timingListener;
   final PostgresQueryTimingListener? _queryTimingListener;
   void Function()? _removeQueryListener;
-  late final _TransactionQueue _transactionQueueRef;
+  late _TransactionQueue _transactionQueueRef;
 
   /// Convenience accessor for the raw ORM connection.
   OrmConnection get connection => _dataSource.connection;

--- a/packages/stem_postgres/lib/src/connection.dart
+++ b/packages/stem_postgres/lib/src/connection.dart
@@ -123,8 +123,8 @@ class PostgresConnections {
         if (_ownsDataSource &&
             (message.contains('already been closed') ||
                 message.contains('not been initialized'))) {
-          await ensureReady(forceReopen: true);
           try {
+            await ensureReady(forceReopen: true);
             final result = await connection.transaction(() => action(context));
             _notifyTiming(
               operation: operation,

--- a/packages/stem_postgres/lib/src/workflow/postgres_workflow_store.dart
+++ b/packages/stem_postgres/lib/src/workflow/postgres_workflow_store.dart
@@ -11,10 +11,9 @@ class PostgresWorkflowStore implements WorkflowStore {
   PostgresWorkflowStore._(
     this._connections, {
     required this.namespace,
-    required WorkflowClock clock,
+    required this._clock,
     Uuid? uuid,
-  }) : _uuid = uuid ?? const Uuid(),
-       _clock = clock;
+  }) : _uuid = uuid ?? const Uuid();
 
   final PostgresConnections _connections;
 

--- a/packages/stem_postgres/lib/src/workflow/postgres_workflow_store.dart
+++ b/packages/stem_postgres/lib/src/workflow/postgres_workflow_store.dart
@@ -1,3 +1,7 @@
+// Public constructor names intentionally initialize private implementation
+// fields to preserve the package API.
+// ignore_for_file: prefer_initializing_formals
+
 import 'dart:convert';
 
 import 'package:ormed/ormed.dart';
@@ -11,9 +15,10 @@ class PostgresWorkflowStore implements WorkflowStore {
   PostgresWorkflowStore._(
     this._connections, {
     required this.namespace,
-    required this._clock,
+    required WorkflowClock clock,
     Uuid? uuid,
-  }) : _uuid = uuid ?? const Uuid();
+  }) : _clock = clock,
+       _uuid = uuid ?? const Uuid();
 
   final PostgresConnections _connections;
 

--- a/packages/stem_postgres/lib/src/workflow/postgres_workflow_store_new.dart
+++ b/packages/stem_postgres/lib/src/workflow/postgres_workflow_store_new.dart
@@ -11,10 +11,9 @@ class PostgresWorkflowStore implements WorkflowStore {
   PostgresWorkflowStore._(
     this._connections, {
     required this.namespace,
-    required WorkflowClock clock,
+    required this._clock,
     Uuid? uuid,
-  }) : _uuid = uuid ?? const Uuid(),
-       _clock = clock;
+  }) : _uuid = uuid ?? const Uuid();
 
   final PostgresConnections _connections;
 

--- a/packages/stem_postgres/lib/src/workflow/postgres_workflow_store_new.dart
+++ b/packages/stem_postgres/lib/src/workflow/postgres_workflow_store_new.dart
@@ -1,3 +1,7 @@
+// Public constructor names intentionally initialize private implementation
+// fields to preserve the package API.
+// ignore_for_file: prefer_initializing_formals
+
 import 'dart:convert';
 
 import 'package:ormed/ormed.dart';
@@ -11,9 +15,10 @@ class PostgresWorkflowStore implements WorkflowStore {
   PostgresWorkflowStore._(
     this._connections, {
     required this.namespace,
-    required this._clock,
+    required WorkflowClock clock,
     Uuid? uuid,
-  }) : _uuid = uuid ?? const Uuid();
+  }) : _clock = clock,
+       _uuid = uuid ?? const Uuid();
 
   final PostgresConnections _connections;
 

--- a/packages/stem_postgres/pubspec.yaml
+++ b/packages/stem_postgres/pubspec.yaml
@@ -1,26 +1,26 @@
 name: stem_postgres
 description: Postgres broker, result backend, and scheduler utilities for Stem.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/kingwill101/stem
 resolution: workspace
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   artisanal: ^0.5.0
   collection: ^1.19.1
   contextual: ^2.2.0
-  ormed: ^0.2.0
-  ormed_postgres: ^0.2.0
+  ormed: ">=0.3.0 <1.0.0"
+  ormed_postgres: ">=0.3.0 <1.0.0"
   path: ^1.9.1
   postgres: ^3.5.9
-  stem: ">=0.3.0 <0.4.0"
+  stem: ">=0.4.0 <0.5.0"
   uuid: ^4.5.2
 
 dev_dependencies:
   build_runner: ^2.10.5
   coverage: ^1.15.0
   lints: ^6.0.0
-  stem_adapter_tests: ^0.2.0
-  test: ^1.29.0
+  stem_adapter_tests: ^0.3.0
+  test: ^1.31.2
   very_good_analysis: ^10.0.0

--- a/packages/stem_postgres/pubspec.yaml
+++ b/packages/stem_postgres/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.0
 repository: https://github.com/kingwill101/stem
 resolution: workspace
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   artisanal: ^0.5.0

--- a/packages/stem_redis/CHANGELOG.md
+++ b/packages/stem_redis/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Changelog
 
-## Unreleased
+## 0.2.0
 
 - Added an atomic Redis Lua terminal-result write that preserves the first
   terminal task state across concurrent workers.
-
-## 0.2.0
-
 - Updated the Redis adapter for Stem 0.3.0 and the capability-aware broker
   contract.
 - Retained the production distributed Redis rate limiter and added its focused

--- a/packages/stem_redis/CHANGELOG.md
+++ b/packages/stem_redis/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0
+
+- Updated the Redis adapter for the Stem 0.4.0 release train and Dart 3.12
+  minimum.
+
 ## 0.2.0
 
 - Added an atomic Redis Lua terminal-result write that preserves the first

--- a/packages/stem_redis/README.md
+++ b/packages/stem_redis/README.md
@@ -5,7 +5,7 @@
 # stem_redis
 
 [![pub package](https://img.shields.io/pub/v/stem_redis.svg)](https://pub.dev/packages/stem_redis)
-[![Dart](https://img.shields.io/badge/dart-%3E%3D3.9.2-blue.svg)](https://dart.dev)
+[![Dart](https://img.shields.io/badge/dart-%3E%3D3.12-blue.svg)](https://dart.dev)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](https://github.com/kingwill101/stem/blob/main/LICENSE)
 [![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kingwill101/stem/main/packages/stem_redis/coverage/coverage.json)](https://github.com/kingwill101/stem/actions/workflows/stem_redis.yaml)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow.svg)](https://www.buymeacoffee.com/kingwill101)

--- a/packages/stem_redis/lib/src/brokers/redis_broker.dart
+++ b/packages/stem_redis/lib/src/brokers/redis_broker.dart
@@ -1,3 +1,7 @@
+// Public constructor names intentionally initialize private implementation
+// fields to preserve the package API.
+// ignore_for_file: prefer_initializing_formals
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -53,8 +57,8 @@ class RedisStreamsBroker
     this.delayedDrainBatch = 128,
     this.defaultVisibilityTimeout = const Duration(seconds: 30),
     this.claimInterval = const Duration(seconds: 30),
-    this._useSharedConnectionForConsumers = false,
-  });
+    bool useSharedConnectionForConsumers = false,
+  }) : _useSharedConnectionForConsumers = useSharedConnectionForConsumers;
 
   /// Namespace used to scope Redis keys.
   final String namespace;

--- a/packages/stem_redis/lib/src/brokers/redis_broker.dart
+++ b/packages/stem_redis/lib/src/brokers/redis_broker.dart
@@ -53,8 +53,8 @@ class RedisStreamsBroker
     this.delayedDrainBatch = 128,
     this.defaultVisibilityTimeout = const Duration(seconds: 30),
     this.claimInterval = const Duration(seconds: 30),
-    bool useSharedConnectionForConsumers = false,
-  }) : _useSharedConnectionForConsumers = useSharedConnectionForConsumers;
+    this._useSharedConnectionForConsumers = false,
+  });
 
   /// Namespace used to scope Redis keys.
   final String namespace;

--- a/packages/stem_redis/lib/src/workflow/redis_workflow_store.dart
+++ b/packages/stem_redis/lib/src/workflow/redis_workflow_store.dart
@@ -1,3 +1,7 @@
+// Public constructor names intentionally initialize private implementation
+// fields to preserve the package API.
+// ignore_for_file: prefer_initializing_formals
+
 import 'dart:convert';
 import 'dart:io';
 
@@ -10,8 +14,8 @@ class RedisWorkflowStore implements WorkflowStore {
     this._connection,
     this._command, {
     required this.namespace,
-    required this._clock,
-  });
+    required WorkflowClock clock,
+  }) : _clock = clock;
 
   final RedisConnection _connection;
   final Command _command;

--- a/packages/stem_redis/lib/src/workflow/redis_workflow_store.dart
+++ b/packages/stem_redis/lib/src/workflow/redis_workflow_store.dart
@@ -10,8 +10,8 @@ class RedisWorkflowStore implements WorkflowStore {
     this._connection,
     this._command, {
     required this.namespace,
-    required WorkflowClock clock,
-  }) : _clock = clock;
+    required this._clock,
+  });
 
   final RedisConnection _connection;
   final Command _command;

--- a/packages/stem_redis/pubspec.yaml
+++ b/packages/stem_redis/pubspec.yaml
@@ -1,21 +1,21 @@
 name: stem_redis
 description: Redis broker, result backend, and scheduler utilities for Stem.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/kingwill101/stem
 resolution: workspace
 environment:
-  sdk: ">=3.9.2 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   async: ^2.13.0
   collection: ^1.19.1
   redis: ^4.0.0
-  stem: ">=0.3.0 <0.4.0"
+  stem: ">=0.4.0 <0.5.0"
   uuid: ^4.5.2
 
 dev_dependencies:
   coverage: ^1.15.0
   lints: ^6.0.0
-  stem_adapter_tests: ^0.2.0
-  test: ^1.29.0
+  stem_adapter_tests: ^0.3.0
+  test: ^1.31.2
   very_good_analysis: ^10.0.0

--- a/packages/stem_redis/test/support/inline_task_handler.dart
+++ b/packages/stem_redis/test/support/inline_task_handler.dart
@@ -1,3 +1,7 @@
+// Public constructor names intentionally initialize private implementation
+// fields to preserve the package API.
+// ignore_for_file: prefer_initializing_formals
+
 import 'dart:async';
 
 import 'package:stem/stem.dart';
@@ -8,9 +12,10 @@ typedef InlineTaskCallback<R> =
 class InlineTaskHandler<R> extends TaskHandler<R> {
   InlineTaskHandler({
     required this.name,
-    required this._onCall,
-    this._options = const TaskOptions(),
-  });
+    required InlineTaskCallback<R> onCall,
+    TaskOptions options = const TaskOptions(),
+  }) : _onCall = onCall,
+       _options = options;
 
   @override
   final String name;

--- a/packages/stem_redis/test/support/inline_task_handler.dart
+++ b/packages/stem_redis/test/support/inline_task_handler.dart
@@ -8,10 +8,9 @@ typedef InlineTaskCallback<R> =
 class InlineTaskHandler<R> extends TaskHandler<R> {
   InlineTaskHandler({
     required this.name,
-    required InlineTaskCallback<R> onCall,
-    TaskOptions options = const TaskOptions(),
-  }) : _onCall = onCall,
-       _options = options;
+    required this._onCall,
+    this._options = const TaskOptions(),
+  });
 
   @override
   final String name;

--- a/packages/stem_sqlite/CHANGELOG.md
+++ b/packages/stem_sqlite/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0
 
 - Datasource logger injection now uses Stem's dependency-neutral `StemLogger`
   facade; the Ormed contextual logger remains an adapter implementation detail.
@@ -15,9 +15,6 @@
   runtime, and worker instances.
 - Added mixed-version queue coverage: a row written against the pre-namespace
   schema is upgraded and consumed by the current SQLite broker.
-
-## 0.2.0
-
 - Updated the adapter for Stem 0.3.0 and the narrowed broker capability model.
 - Added migration-registry and historical-schema upgrade coverage.
 - Removed the deprecated `StemSqliteDatabase` placeholder API; use

--- a/packages/stem_sqlite/CHANGELOG.md
+++ b/packages/stem_sqlite/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2.0
 
+- Widened the `ormed_sqlite` dependency to support its compatible stable 0.2
+  and 0.3 release lines.
 - Datasource logger injection now uses Stem's dependency-neutral `StemLogger`
   facade; the Ormed contextual logger remains an adapter implementation detail.
 - Serialized SQLite transactions and broker mutations across shared file

--- a/packages/stem_sqlite/CHANGELOG.md
+++ b/packages/stem_sqlite/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.2.0
 
-- Widened the `ormed_sqlite` dependency to support its compatible stable 0.2
-  and 0.3 release lines.
+- Widened the `ormed_sqlite` dependency across its compatible pre-1.0
+  release line.
 - Datasource logger injection now uses Stem's dependency-neutral `StemLogger`
   facade; the Ormed contextual logger remains an adapter implementation detail.
 - Serialized SQLite transactions and broker mutations across shared file

--- a/packages/stem_sqlite/CHANGELOG.md
+++ b/packages/stem_sqlite/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
+## 0.3.0
+
+- Raised the minimum Dart SDK to 3.12.0 and the Ormed dependencies to 0.3.0
+  and `ormed_sqlite` 0.4.0.
+- Retained generated model definitions for Stem's internal typed repositories;
+  Ormed's codegen-free database facade remains available for application-side
+  ad-hoc access.
+
 ## 0.2.0
 
-- Widened the `ormed_sqlite` dependency across its compatible pre-1.0
-  release line.
 - Datasource logger injection now uses Stem's dependency-neutral `StemLogger`
   facade; the Ormed contextual logger remains an adapter implementation detail.
 - Serialized SQLite transactions and broker mutations across shared file

--- a/packages/stem_sqlite/README.md
+++ b/packages/stem_sqlite/README.md
@@ -5,7 +5,7 @@
 # stem_sqlite
 
 [![pub package](https://img.shields.io/pub/v/stem_sqlite.svg)](https://pub.dev/packages/stem_sqlite)
-[![Dart](https://img.shields.io/badge/dart-%3E%3D3.9.2-blue.svg)](https://dart.dev)
+[![Dart](https://img.shields.io/badge/dart-%3E%3D3.12-blue.svg)](https://dart.dev)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](https://github.com/kingwill101/stem/blob/main/LICENSE)
 [![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kingwill101/stem/main/packages/stem_sqlite/coverage/coverage.json)](https://github.com/kingwill101/stem/actions/workflows/stem_sqlite.yaml)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow.svg)](https://www.buymeacoffee.com/kingwill101)

--- a/packages/stem_sqlite/dart_test.yaml
+++ b/packages/stem_sqlite/dart_test.yaml
@@ -1,0 +1,1 @@
+concurrency: 1

--- a/packages/stem_sqlite/lib/orm_registry.g.dart
+++ b/packages/stem_sqlite/lib/orm_registry.g.dart
@@ -1,0 +1,2 @@
+// Preserve the public registry import path used by earlier releases.
+export 'src/database/orm_registry.g.dart';

--- a/packages/stem_sqlite/lib/src/backend/sqlite_result_backend.dart
+++ b/packages/stem_sqlite/lib/src/backend/sqlite_result_backend.dart
@@ -175,8 +175,6 @@ class SqliteResultBackend
     Map<String, Object?> meta = const {},
     Duration? ttl,
   }) async {
-    final now = stemNow();
-    final expiresAt = now.add(ttl ?? defaultTtl);
     final status = TaskStatus(
       id: taskId,
       state: state,
@@ -187,6 +185,7 @@ class SqliteResultBackend
     );
 
     await _connections.runInTransaction((txn) async {
+      final expiresAt = stemNow().add(ttl ?? defaultTtl);
       final model = $StemTaskResult(
         id: taskId,
         namespace: namespace,
@@ -208,9 +207,9 @@ class SqliteResultBackend
     TaskStatus status, {
     Duration? ttl,
   }) async {
-    final now = stemNow();
-    final expiresAt = now.add(ttl ?? defaultTtl);
     final updated = await _connections.runInTransaction((txn) {
+      final now = stemNow();
+      final expiresAt = now.add(ttl ?? defaultTtl);
       final query = txn
           .query<StemTaskResult>()
           .whereEquals('id', status.id)
@@ -335,9 +334,8 @@ class SqliteResultBackend
 
   @override
   Future<void> setWorkerHeartbeat(WorkerHeartbeat heartbeat) async {
-    final now = stemNow();
-    final expiresAt = now.add(heartbeatTtl);
     await _connections.runInTransaction((txn) async {
+      final expiresAt = stemNow().add(heartbeatTtl);
       final model = StemWorkerHeartbeat(
         workerId: heartbeat.workerId,
         namespace: namespace,
@@ -385,9 +383,8 @@ class SqliteResultBackend
 
   @override
   Future<void> initGroup(GroupDescriptor descriptor) async {
-    final now = stemNow();
-    final expiresAt = now.add(descriptor.ttl ?? groupDefaultTtl);
     await _connections.runInTransaction((txn) async {
+      final expiresAt = stemNow().add(descriptor.ttl ?? groupDefaultTtl);
       await txn.repository<StemGroup>().upsert(
         StemGroupInsertDto(
           id: descriptor.id,

--- a/packages/stem_sqlite/lib/src/connection.dart
+++ b/packages/stem_sqlite/lib/src/connection.dart
@@ -4,8 +4,8 @@ import 'dart:io';
 import 'package:ormed/ormed.dart';
 import 'package:ormed_sqlite/ormed_sqlite.dart';
 
-import 'package:stem_sqlite/orm_registry.g.dart';
 import 'package:stem_sqlite/src/database/migrations.dart';
+import 'package:stem_sqlite/src/database/orm_registry.g.dart';
 
 const int _sqliteBusyTimeoutMs = 5000;
 

--- a/packages/stem_sqlite/lib/src/connection.dart
+++ b/packages/stem_sqlite/lib/src/connection.dart
@@ -1,3 +1,7 @@
+// Public constructor names intentionally initialize private implementation
+// fields to preserve the package API.
+// ignore_for_file: prefer_initializing_formals
+
 import 'dart:async';
 import 'dart:io';
 
@@ -24,9 +28,10 @@ class SqliteConnections {
   /// Creates a connection wrapper for an initialized data source.
   SqliteConnections._(
     this.dataSource, {
-    required this._ownsDataSource,
-    this._coordinationKey,
-  });
+    required bool ownsDataSource,
+    String? coordinationKey,
+  }) : _ownsDataSource = ownsDataSource,
+       _coordinationKey = coordinationKey;
 
   /// Underlying data source instance.
   final DataSource dataSource;

--- a/packages/stem_sqlite/lib/src/connection.dart
+++ b/packages/stem_sqlite/lib/src/connection.dart
@@ -24,10 +24,9 @@ class SqliteConnections {
   /// Creates a connection wrapper for an initialized data source.
   SqliteConnections._(
     this.dataSource, {
-    required bool ownsDataSource,
-    String? coordinationKey,
-  }) : _ownsDataSource = ownsDataSource,
-       _coordinationKey = coordinationKey;
+    required this._ownsDataSource,
+    this._coordinationKey,
+  });
 
   /// Underlying data source instance.
   final DataSource dataSource;

--- a/packages/stem_sqlite/lib/src/database/datasource.dart
+++ b/packages/stem_sqlite/lib/src/database/datasource.dart
@@ -1,7 +1,7 @@
 import 'package:ormed/ormed.dart';
 import 'package:ormed_sqlite/ormed_sqlite.dart';
 import 'package:stem/observability.dart' show StemLogger, stemLogger;
-import 'package:stem_sqlite/orm_registry.g.dart';
+import 'package:stem_sqlite/src/database/orm_registry.g.dart';
 import 'package:stem_sqlite/src/database/stem_orm_logger.dart';
 
 /// Creates a new DataSource instance using the project configuration.

--- a/packages/stem_sqlite/lib/src/database/orm_registry.g.dart
+++ b/packages/stem_sqlite/lib/src/database/orm_registry.g.dart
@@ -1,16 +1,16 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // coverage:ignore-file
 import 'package:ormed/ormed.dart';
-import 'src/models/stem_dead_letter.dart';
-import 'src/models/stem_group.dart';
-import 'src/models/stem_group_result.dart';
-import 'src/models/stem_queue_job.dart';
-import 'src/models/stem_revoke_entry.dart';
-import 'src/models/stem_task_result.dart';
-import 'src/models/stem_worker_heartbeat.dart';
-import 'src/models/stem_workflow_run.dart';
-import 'src/models/stem_workflow_step.dart';
-import 'src/models/stem_workflow_watcher.dart';
+import 'package:stem_sqlite/src/models/stem_dead_letter.dart';
+import 'package:stem_sqlite/src/models/stem_group.dart';
+import 'package:stem_sqlite/src/models/stem_group_result.dart';
+import 'package:stem_sqlite/src/models/stem_queue_job.dart';
+import 'package:stem_sqlite/src/models/stem_revoke_entry.dart';
+import 'package:stem_sqlite/src/models/stem_task_result.dart';
+import 'package:stem_sqlite/src/models/stem_worker_heartbeat.dart';
+import 'package:stem_sqlite/src/models/stem_workflow_run.dart';
+import 'package:stem_sqlite/src/models/stem_workflow_step.dart';
+import 'package:stem_sqlite/src/models/stem_workflow_watcher.dart';
 
 final List<ModelDefinition<OrmEntity>> _$ormModelDefinitions = [
   StemDeadLetterOrmDefinition.definition,

--- a/packages/stem_sqlite/lib/src/database/seeders.dart
+++ b/packages/stem_sqlite/lib/src/database/seeders.dart
@@ -1,5 +1,5 @@
 import 'package:ormed/ormed.dart';
-import 'package:stem_sqlite/orm_registry.g.dart';
+import 'package:stem_sqlite/src/database/orm_registry.g.dart';
 import 'package:stem_sqlite/src/database/seed_runtime.dart';
 import 'package:stem_sqlite/src/database/seeders/database_seeder.dart';
 

--- a/packages/stem_sqlite/lib/stem_sqlite.dart
+++ b/packages/stem_sqlite/lib/stem_sqlite.dart
@@ -1,9 +1,9 @@
-export 'orm_registry.g.dart';
 export 'src/backend/sqlite_result_backend.dart' show SqliteResultBackend;
 export 'src/broker/sqlite_broker.dart' show SqliteBroker;
 export 'src/connection.dart' show SqliteConnections;
 export 'src/control/sqlite_revoke_store.dart' show SqliteRevokeStore;
 export 'src/database/datasource.dart' show createDataSource;
+export 'src/database/orm_registry.g.dart';
 export 'src/models/models.dart';
 export 'src/stack/sqlite_adapter.dart' show StemSqliteAdapter;
 export 'src/workflow/sqlite_factories.dart'

--- a/packages/stem_sqlite/pubspec.yaml
+++ b/packages/stem_sqlite/pubspec.yaml
@@ -1,27 +1,27 @@
 name: stem_sqlite
 description: SQLite broker and result backend for Stem.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/kingwill101/stem
 resolution: workspace
 environment:
-  sdk: ^3.10.0
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   artisanal: ^0.5.0
   collection: ^1.19.1
   contextual: ^2.2.0
   meta: ^1.18.0
-  ormed: ^0.2.0
-  # Keep compatibility across the pre-1.0 SQLite adapter line.
-  ormed_sqlite: ">=0.2.0 <1.0.0"
+  ormed: ">=0.3.0 <1.0.0"
+  # Keep compatibility across the remaining pre-1.0 SQLite adapter line.
+  ormed_sqlite: ">=0.4.0 <1.0.0"
   path: ^1.9.1
-  stem: ">=0.3.0 <0.4.0"
+  stem: ">=0.4.0 <0.5.0"
   uuid: ^4.5.2
 
 dev_dependencies:
   build_runner: ^2.10.5
   coverage: ^1.15.0
   lints: ^6.0.0
-  stem_adapter_tests: ">=0.2.0 <0.3.0"
-  test: ^1.29.0
+  stem_adapter_tests: ">=0.3.0 <0.4.0"
+  test: ^1.31.2
   very_good_analysis: ^10.0.0

--- a/packages/stem_sqlite/pubspec.yaml
+++ b/packages/stem_sqlite/pubspec.yaml
@@ -12,7 +12,8 @@ dependencies:
   contextual: ^2.2.0
   meta: ^1.18.0
   ormed: ^0.2.0
-  ormed_sqlite: ^0.3.0
+  # Keep compatibility with the 0.2 and 0.3 SQLite adapter lines.
+  ormed_sqlite: ">=0.2.0 <0.4.0"
   path: ^1.9.1
   stem: ">=0.3.0 <0.4.0"
   uuid: ^4.5.2

--- a/packages/stem_sqlite/pubspec.yaml
+++ b/packages/stem_sqlite/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   contextual: ^2.2.0
   meta: ^1.18.0
   ormed: ^0.2.0
-  # Keep compatibility with the 0.2 and 0.3 SQLite adapter lines.
-  ormed_sqlite: ">=0.2.0 <0.4.0"
+  # Keep compatibility across the pre-1.0 SQLite adapter line.
+  ormed_sqlite: ">=0.2.0 <1.0.0"
   path: ^1.9.1
   stem: ">=0.3.0 <0.4.0"
   uuid: ^4.5.2

--- a/packages/stem_sqlite/test/backend/sqlite_result_backend_test.dart
+++ b/packages/stem_sqlite/test/backend/sqlite_result_backend_test.dart
@@ -29,9 +29,9 @@ void main() {
     factory: ResultBackendContractFactory(
       create: () async => SqliteResultBackend.open(
         dbFile,
-        defaultTtl: const Duration(seconds: 1),
-        groupDefaultTtl: const Duration(seconds: 1),
-        heartbeatTtl: const Duration(seconds: 1),
+        defaultTtl: const Duration(seconds: 5),
+        groupDefaultTtl: const Duration(seconds: 5),
+        heartbeatTtl: const Duration(seconds: 5),
         cleanupInterval: const Duration(milliseconds: 200),
       ),
       dispose: (backend) => (backend as SqliteResultBackend).close(),
@@ -43,7 +43,10 @@ void main() {
           (backend as SqliteResultBackend).runCleanup(),
     ),
     settings: const ResultBackendContractSettings(
-      settleDelay: Duration(milliseconds: 120),
+      statusTtl: Duration(seconds: 5),
+      groupTtl: Duration(seconds: 5),
+      heartbeatTtl: Duration(seconds: 5),
+      settleDelay: Duration(milliseconds: 250),
     ),
   );
 

--- a/packages/stem_sqlite/test/migration_upgrade_test.dart
+++ b/packages/stem_sqlite/test/migration_upgrade_test.dart
@@ -8,6 +8,8 @@ import 'package:stem_sqlite/src/database/migrations.dart';
 import 'package:stem_sqlite/stem_sqlite.dart';
 import 'package:test/test.dart';
 
+const _migrationTestTimeout = Timeout(Duration(minutes: 5));
+
 void main() {
   test(
     'upgrades every historical schema prefix to the current registry',
@@ -69,56 +71,61 @@ void main() {
         }
       }
     },
+    timeout: _migrationTestTimeout,
   );
 
-  test('current additive schema accepts legacy-shaped queue writes', () async {
-    final directory = await Directory.systemTemp.createTemp(
-      'stem-sqlite-mixed-version-',
-    );
-    final file = File('${directory.path}/stem.db');
-    try {
-      final adapter = SqliteDriverAdapter.file(file.path);
-      final runner = MigrationRunner(
-        schemaDriver: adapter,
-        ledger: SqlMigrationLedger(adapter, tableName: 'orm_migrations'),
-        migrations: buildMigrations(),
-        emitEvents: false,
+  test(
+    'current additive schema accepts legacy-shaped queue writes',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'stem-sqlite-mixed-version-',
       );
-      await runner.applyAll();
+      final file = File('${directory.path}/stem.db');
+      try {
+        final adapter = SqliteDriverAdapter.file(file.path);
+        final runner = MigrationRunner(
+          schemaDriver: adapter,
+          ledger: SqlMigrationLedger(adapter, tableName: 'orm_migrations'),
+          migrations: buildMigrations(),
+          emitEvents: false,
+        );
+        await runner.applyAll();
 
-      final now = DateTime.now().toUtc();
-      await adapter.executeRaw(
-        '''
+        final now = DateTime.now().toUtc();
+        await adapter.executeRaw(
+          '''
 INSERT INTO stem_queue_jobs
   (id, queue, envelope, attempt, max_retries, priority, not_before,
    locked_at, locked_until, locked_by, created_at, updated_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ''',
-        [
-          'legacy-queue-job',
-          'default',
-          jsonEncode({'name': 'legacy.task', 'args': <String, Object?>{}}),
-          0,
-          0,
-          0,
-          null,
-          null,
-          null,
-          null,
-          now,
-          now,
-        ],
-      );
-      final rows = await adapter.queryRaw(
-        'SELECT namespace FROM stem_queue_jobs WHERE id = ?',
-        ['legacy-queue-job'],
-      );
-      expect(rows.single['namespace'], equals('stem'));
-      await adapter.close();
-    } finally {
-      await directory.delete(recursive: true);
-    }
-  });
+          [
+            'legacy-queue-job',
+            'default',
+            jsonEncode({'name': 'legacy.task', 'args': <String, Object?>{}}),
+            0,
+            0,
+            0,
+            null,
+            null,
+            null,
+            null,
+            now,
+            now,
+          ],
+        );
+        final rows = await adapter.queryRaw(
+          'SELECT namespace FROM stem_queue_jobs WHERE id = ?',
+          ['legacy-queue-job'],
+        );
+        expect(rows.single['namespace'], equals('stem'));
+        await adapter.close();
+      } finally {
+        await directory.delete(recursive: true);
+      }
+    },
+    timeout: _migrationTestTimeout,
+  );
 
   test(
     'current broker consumes a queue row written before namespace migration',
@@ -183,5 +190,6 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         await directory.delete(recursive: true);
       }
     },
+    timeout: _migrationTestTimeout,
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stem_and_friends
 publish_to: none
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 workspace:
   - repodoc
   - packages/stem
@@ -20,3 +20,10 @@ dev_dependencies:
   crypto: ^3.0.7
   yaml: ^3.1.3
   very_good_analysis: ^10.0.0
+
+dependency_overrides:
+  # Flutter 3.47.1 still pins flutter_test to test_api 0.7.12, while the
+  # analyzer 14 toolchain required by Ormed 0.3 resolves test 1.31.2,
+  # which requires test_api 0.7.13. Keep this override at the workspace root
+  # only; it is not part of any published package's consumer resolution.
+  test_api: 0.7.13

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,5 +17,6 @@ workspace:
 dev_dependencies:
   artisanal: ^0.5.0
   coverage: ^1.15.0
+  crypto: ^3.0.7
   yaml: ^3.1.3
   very_good_analysis: ^10.0.0

--- a/repodoc/README.md
+++ b/repodoc/README.md
@@ -5,7 +5,7 @@ workspace discovery, dependency resolution, quality checks, tests, coverage,
 examples, standalone dependency resolution, repeatable job profiling, and
 store-backed throughput benchmarking.
 
-Repodoc requires Dart 3.10.0 or newer. The repository's recommended devenv
+Repodoc requires Dart 3.12.0 or newer. The repository's recommended devenv
 environment remains the easiest way to provision the supported toolchain.
 
 Use it through devenv when possible:

--- a/repodoc/lib/src/benchmarks/throughput.dart
+++ b/repodoc/lib/src/benchmarks/throughput.dart
@@ -172,6 +172,7 @@ final class ThroughputBenchmark {
           tasks,
           label: 'measured enqueue',
           stage: stage,
+          watchBackend: executionBackend,
           terminalWaiters: measuredWaiters,
         );
         return;
@@ -185,7 +186,7 @@ final class ThroughputBenchmark {
         measuredTasks += 1;
         final enqueuedAtMicros = DateTime.now().microsecondsSinceEpoch;
         final taskId = generateEnvelopeId();
-        measuredWaiters.add(_watchTerminal(backend, taskId));
+        measuredWaiters.add(_watchTerminal(executionBackend, taskId));
         await stem.enqueue(
           'repodoc.benchmark.noop',
           args: {'index': index},
@@ -350,6 +351,7 @@ Future<void> _enqueueTasks(
   int count, {
   required String label,
   required void Function(String message) stage,
+  ResultBackend? watchBackend,
   List<Future<_ObservedTerminal>>? terminalWaiters,
 }) async {
   final progressEvery = count < 20 ? 1 : (count / 20).ceil();
@@ -357,7 +359,7 @@ Future<void> _enqueueTasks(
     final enqueuedAtMicros = DateTime.now().microsecondsSinceEpoch;
     final taskId = generateEnvelopeId();
     if (terminalWaiters != null) {
-      terminalWaiters.add(_watchTerminal(backend, taskId));
+      terminalWaiters.add(_watchTerminal(watchBackend ?? backend, taskId));
     }
     await stem.enqueue(
       'repodoc.benchmark.noop',

--- a/repodoc/lib/src/benchmarks/throughput.dart
+++ b/repodoc/lib/src/benchmarks/throughput.dart
@@ -100,7 +100,7 @@ final class ThroughputBenchmark {
     var warmupCompletedTasks = 0;
     var measuredTasks = 0;
     final taskLatencies = <double>[];
-    final measuredWaiters = <Future<_ObservedTerminal>>[];
+    final measuredWatchers = <_TerminalWatcher>[];
 
     final registry = InMemoryTaskRegistry()
       ..register(
@@ -173,7 +173,7 @@ final class ThroughputBenchmark {
           label: 'measured enqueue',
           stage: stage,
           watchBackend: executionBackend,
-          terminalWaiters: measuredWaiters,
+          terminalWatchers: measuredWatchers,
         );
         return;
       }
@@ -186,7 +186,7 @@ final class ThroughputBenchmark {
         measuredTasks += 1;
         final enqueuedAtMicros = DateTime.now().microsecondsSinceEpoch;
         final taskId = generateEnvelopeId();
-        measuredWaiters.add(_watchTerminal(executionBackend, taskId));
+        measuredWatchers.add(_watchTerminal(executionBackend, taskId));
         await stem.enqueue(
           'repodoc.benchmark.noop',
           args: {'index': index},
@@ -206,7 +206,7 @@ final class ThroughputBenchmark {
 
     Future<void> awaitMeasuredStatuses() async {
       final statuses = await Future.wait(
-        measuredWaiters,
+        measuredWatchers.map((watcher) => watcher.future),
       ).timeout(const Duration(minutes: 2));
       for (final terminal in statuses) {
         final latency = _observedTaskLatencyMs(terminal);
@@ -284,11 +284,17 @@ final class ThroughputBenchmark {
       try {
         await shutdownWorker();
       } finally {
-        stage('closing store resources');
         try {
-          await resources.close();
+          await Future.wait(
+            measuredWatchers.map((watcher) => watcher.cancel()),
+          );
         } finally {
-          stage('benchmark complete');
+          stage('closing store resources');
+          try {
+            await resources.close();
+          } finally {
+            stage('benchmark complete');
+          }
         }
       }
     }
@@ -352,14 +358,14 @@ Future<void> _enqueueTasks(
   required String label,
   required void Function(String message) stage,
   ResultBackend? watchBackend,
-  List<Future<_ObservedTerminal>>? terminalWaiters,
+  List<_TerminalWatcher>? terminalWatchers,
 }) async {
   final progressEvery = count < 20 ? 1 : (count / 20).ceil();
   for (var index = 0; index < count; index++) {
     final enqueuedAtMicros = DateTime.now().microsecondsSinceEpoch;
     final taskId = generateEnvelopeId();
-    if (terminalWaiters != null) {
-      terminalWaiters.add(_watchTerminal(watchBackend ?? backend, taskId));
+    if (terminalWatchers != null) {
+      terminalWatchers.add(_watchTerminal(watchBackend ?? backend, taskId));
     }
     await stem.enqueue(
       'repodoc.benchmark.noop',
@@ -381,7 +387,7 @@ final class _ObservedTerminal {
   final int observedAtMicros;
 }
 
-Future<_ObservedTerminal> _watchTerminal(ResultBackend backend, String taskId) {
+_TerminalWatcher _watchTerminal(ResultBackend backend, String taskId) {
   final completer = Completer<_ObservedTerminal>();
   late StreamSubscription<TaskStatus> subscription;
   subscription = backend
@@ -395,10 +401,13 @@ Future<_ObservedTerminal> _watchTerminal(ResultBackend backend, String taskId) {
           unawaited(subscription.cancel());
         },
         onError: (Object error, StackTrace stackTrace) {
-          if (!completer.isCompleted)
+          unawaited(subscription.cancel());
+          if (!completer.isCompleted) {
             completer.completeError(error, stackTrace);
+          }
         },
         onDone: () {
+          unawaited(subscription.cancel());
           if (!completer.isCompleted) {
             completer.completeError(
               StateError('Benchmark status stream closed before completion.'),
@@ -406,7 +415,16 @@ Future<_ObservedTerminal> _watchTerminal(ResultBackend backend, String taskId) {
           }
         },
       );
-  return completer.future;
+  return _TerminalWatcher(completer.future, subscription.cancel);
+}
+
+final class _TerminalWatcher {
+  const _TerminalWatcher(this.future, this._cancel);
+
+  final Future<_ObservedTerminal> future;
+  final Future<void> Function() _cancel;
+
+  Future<void> cancel() => _cancel();
 }
 
 double? _observedTaskLatencyMs(_ObservedTerminal terminal) {

--- a/repodoc/lib/src/benchmarks/throughput.dart
+++ b/repodoc/lib/src/benchmarks/throughput.dart
@@ -100,7 +100,7 @@ final class ThroughputBenchmark {
     var warmupCompletedTasks = 0;
     var measuredTasks = 0;
     final taskLatencies = <double>[];
-    final measuredWaiters = <Future<TaskStatus>>[];
+    final measuredWaiters = <Future<_ObservedTerminal>>[];
 
     final registry = InMemoryTaskRegistry()
       ..register(
@@ -207,8 +207,8 @@ final class ThroughputBenchmark {
       final statuses = await Future.wait(
         measuredWaiters,
       ).timeout(const Duration(minutes: 2));
-      for (final status in statuses) {
-        final latency = _observedTaskLatencyMs(status);
+      for (final terminal in statuses) {
+        final latency = _observedTaskLatencyMs(terminal);
         if (latency != null) taskLatencies.add(latency);
       }
     }
@@ -350,7 +350,7 @@ Future<void> _enqueueTasks(
   int count, {
   required String label,
   required void Function(String message) stage,
-  List<Future<TaskStatus>>? terminalWaiters,
+  List<Future<_ObservedTerminal>>? terminalWaiters,
 }) async {
   final progressEvery = count < 20 ? 1 : (count / 20).ceil();
   for (var index = 0; index < count; index++) {
@@ -372,15 +372,24 @@ Future<void> _enqueueTasks(
   }
 }
 
-Future<TaskStatus> _watchTerminal(ResultBackend backend, String taskId) {
-  final completer = Completer<TaskStatus>();
+final class _ObservedTerminal {
+  const _ObservedTerminal(this.status, this.observedAtMicros);
+
+  final TaskStatus status;
+  final int observedAtMicros;
+}
+
+Future<_ObservedTerminal> _watchTerminal(ResultBackend backend, String taskId) {
+  final completer = Completer<_ObservedTerminal>();
   late StreamSubscription<TaskStatus> subscription;
   subscription = backend
       .watch(taskId)
       .listen(
         (status) {
           if (!status.state.isTerminal || completer.isCompleted) return;
-          completer.complete(status);
+          completer.complete(
+            _ObservedTerminal(status, DateTime.now().microsecondsSinceEpoch),
+          );
           unawaited(subscription.cancel());
         },
         onError: (Object error, StackTrace stackTrace) {
@@ -398,10 +407,11 @@ Future<TaskStatus> _watchTerminal(ResultBackend backend, String taskId) {
   return completer.future;
 }
 
-double? _observedTaskLatencyMs(TaskStatus status) {
-  final enqueuedAt = (status.meta['enqueuedAtMicros'] as num?)?.toInt();
+double? _observedTaskLatencyMs(_ObservedTerminal terminal) {
+  final enqueuedAt = (terminal.status.meta['enqueuedAtMicros'] as num?)
+      ?.toInt();
   if (enqueuedAt == null) return null;
-  return (DateTime.now().microsecondsSinceEpoch - enqueuedAt) /
+  return (terminal.observedAtMicros - enqueuedAt) /
       Duration.microsecondsPerMillisecond;
 }
 

--- a/repodoc/lib/src/benchmarks/throughput.dart
+++ b/repodoc/lib/src/benchmarks/throughput.dart
@@ -95,21 +95,12 @@ final class ThroughputBenchmark {
     final backend = resources.backend;
     final executionBroker = resources.executionBroker;
     final executionBackend = resources.executionBackend;
-    final completed = Completer<void>();
     final warmupCompleted = Completer<void>();
     var measuring = false;
-    var measurementClosed = false;
     var warmupCompletedTasks = 0;
     var measuredTasks = 0;
-    var completedTasks = 0;
     final taskLatencies = <double>[];
-    void completeMeasuredIfReady() {
-      if (measurementClosed &&
-          completedTasks >= measuredTasks &&
-          !completed.isCompleted) {
-        completed.complete();
-      }
-    }
+    final measuredWaiters = <Future<TaskStatus>>[];
 
     final registry = InMemoryTaskRegistry()
       ..register(
@@ -122,13 +113,7 @@ final class ThroughputBenchmark {
                   !warmupCompleted.isCompleted) {
                 warmupCompleted.complete();
               }
-              return;
             }
-            completedTasks += 1;
-            completeMeasuredIfReady();
-          },
-          recordLatency: (latency) {
-            if (measuring) taskLatencies.add(latency);
           },
         ),
       );
@@ -166,6 +151,7 @@ final class ThroughputBenchmark {
       stage('enqueueing $warmupTasks warmup tasks');
       await _enqueueTasks(
         stem,
+        backend,
         warmupTasks,
         label: 'warmup enqueue',
         stage: stage,
@@ -182,12 +168,12 @@ final class ThroughputBenchmark {
         measuredTasks = tasks;
         await _enqueueTasks(
           stem,
+          backend,
           tasks,
           label: 'measured enqueue',
           stage: stage,
+          terminalWaiters: measuredWaiters,
         );
-        measurementClosed = true;
-        completeMeasuredIfReady();
         return;
       }
 
@@ -197,12 +183,14 @@ final class ThroughputBenchmark {
       while (window.elapsed < duration) {
         final index = measuredTasks;
         measuredTasks += 1;
+        final enqueuedAtMicros = DateTime.now().microsecondsSinceEpoch;
+        final taskId = generateEnvelopeId();
+        measuredWaiters.add(_watchTerminal(backend, taskId));
         await stem.enqueue(
           'repodoc.benchmark.noop',
-          args: {
-            'index': index,
-            'enqueuedAtMicros': DateTime.now().microsecondsSinceEpoch,
-          },
+          args: {'index': index},
+          meta: {'enqueuedAtMicros': enqueuedAtMicros},
+          enqueueOptions: TaskEnqueueOptions(taskId: taskId),
         );
         if (window.elapsed >= nextProgress) {
           stage(
@@ -213,8 +201,16 @@ final class ThroughputBenchmark {
         }
       }
       window.stop();
-      measurementClosed = true;
-      completeMeasuredIfReady();
+    }
+
+    Future<void> awaitMeasuredStatuses() async {
+      final statuses = await Future.wait(
+        measuredWaiters,
+      ).timeout(const Duration(minutes: 2));
+      for (final status in statuses) {
+        final latency = _observedTaskLatencyMs(status);
+        if (latency != null) taskLatencies.add(latency);
+      }
     }
 
     try {
@@ -236,7 +232,7 @@ final class ThroughputBenchmark {
         stage('prefill complete; starting worker drain');
         final total = Stopwatch()..start();
         await startWorker();
-        await completed.future.timeout(const Duration(minutes: 2));
+        await awaitMeasuredStatuses();
         final handlerEndToEnd = total.elapsed;
         stage('handlers complete; waiting for broker drain');
         await _waitForBrokerDrain(broker);
@@ -268,7 +264,7 @@ final class ThroughputBenchmark {
       }
 
       stage('measured enqueue complete; waiting for handlers');
-      await completed.future.timeout(const Duration(minutes: 2));
+      await awaitMeasuredStatuses();
       final handlerEndToEnd = total.elapsed;
       stage('handlers complete; waiting for broker drain');
       await _waitForBrokerDrain(broker);
@@ -350,24 +346,63 @@ final class ThroughputBenchmark {
 
 Future<void> _enqueueTasks(
   Stem stem,
+  ResultBackend backend,
   int count, {
   required String label,
   required void Function(String message) stage,
+  List<Future<TaskStatus>>? terminalWaiters,
 }) async {
   final progressEvery = count < 20 ? 1 : (count / 20).ceil();
   for (var index = 0; index < count; index++) {
+    final enqueuedAtMicros = DateTime.now().microsecondsSinceEpoch;
+    final taskId = generateEnvelopeId();
+    if (terminalWaiters != null) {
+      terminalWaiters.add(_watchTerminal(backend, taskId));
+    }
     await stem.enqueue(
       'repodoc.benchmark.noop',
-      args: {
-        'index': index,
-        'enqueuedAtMicros': DateTime.now().microsecondsSinceEpoch,
-      },
+      args: {'index': index},
+      meta: {'enqueuedAtMicros': enqueuedAtMicros},
+      enqueueOptions: TaskEnqueueOptions(taskId: taskId),
     );
     final completed = index + 1;
     if (completed == count || completed % progressEvery == 0) {
       stage('$label progress: $completed/$count');
     }
   }
+}
+
+Future<TaskStatus> _watchTerminal(ResultBackend backend, String taskId) {
+  final completer = Completer<TaskStatus>();
+  late StreamSubscription<TaskStatus> subscription;
+  subscription = backend
+      .watch(taskId)
+      .listen(
+        (status) {
+          if (!status.state.isTerminal || completer.isCompleted) return;
+          completer.complete(status);
+          unawaited(subscription.cancel());
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (!completer.isCompleted)
+            completer.completeError(error, stackTrace);
+        },
+        onDone: () {
+          if (!completer.isCompleted) {
+            completer.completeError(
+              StateError('Benchmark status stream closed before completion.'),
+            );
+          }
+        },
+      );
+  return completer.future;
+}
+
+double? _observedTaskLatencyMs(TaskStatus status) {
+  final enqueuedAt = (status.meta['enqueuedAtMicros'] as num?)?.toInt();
+  if (enqueuedAt == null) return null;
+  return (DateTime.now().microsecondsSinceEpoch - enqueuedAt) /
+      Duration.microsecondsPerMillisecond;
 }
 
 Future<void> _waitForBrokerDrain(QueueBroker broker) async {
@@ -403,15 +438,10 @@ double _rate(int count, Duration duration) {
 }
 
 final class _ThroughputTask extends TaskHandler<void> {
-  _ThroughputTask({
-    required this.scenario,
-    required this.onTerminal,
-    required this.recordLatency,
-  });
+  _ThroughputTask({required this.scenario, required this.onTerminal});
 
   final ThroughputScenario scenario;
   final void Function() onTerminal;
-  final void Function(double latencyMs) recordLatency;
 
   @override
   String get name => 'repodoc.benchmark.noop';
@@ -421,15 +451,7 @@ final class _ThroughputTask extends TaskHandler<void> {
 
   @override
   Future<void> call(TaskContext context, Map<String, Object?> args) async {
-    void recordTerminal() {
-      final enqueuedAtMicros = (args['enqueuedAtMicros'] as num?)?.toInt();
-      if (enqueuedAtMicros != null) {
-        final elapsedMicros =
-            DateTime.now().microsecondsSinceEpoch - enqueuedAtMicros;
-        recordLatency(elapsedMicros / Duration.microsecondsPerMillisecond);
-      }
-      onTerminal();
-    }
+    void recordTerminal() => onTerminal();
 
     switch (scenario) {
       case ThroughputScenario.success:

--- a/repodoc/lib/src/benchmarks/throughput_store.dart
+++ b/repodoc/lib/src/benchmarks/throughput_store.dart
@@ -224,10 +224,14 @@ Future<ThroughputStoreResources> openThroughputStore({
         );
         log?.call('Redis result backend ready');
         return ThroughputStoreResources(broker: broker, backend: backend);
-      } on Object {
+      } on Object catch (error, stackTrace) {
         log?.call('Redis result backend failed; closing broker');
-        await broker.close();
-        rethrow;
+        try {
+          await broker.close();
+        } on Object catch (closeError) {
+          log?.call('failed to close Redis broker: $closeError');
+        }
+        Error.throwWithStackTrace(error, stackTrace);
       }
   }
 }

--- a/repodoc/lib/src/commands/coverage_command.dart
+++ b/repodoc/lib/src/commands/coverage_command.dart
@@ -131,6 +131,9 @@ final class CoverageRunner {
             'STEM_CLI_RUN_MULTI': 'true',
           }
         : environment;
+    if (coverageDirectory.existsSync()) {
+      await coverageDirectory.delete(recursive: true);
+    }
     await runner.run(
       'dart',
       [

--- a/repodoc/lib/src/commands/profile_job_command.dart
+++ b/repodoc/lib/src/commands/profile_job_command.dart
@@ -27,7 +27,9 @@ final class ProfileJobCommand extends Command<int> {
   String get name => commandName;
 
   @override
-  String get description => 'Run repeated AOT profiling trials for Stem jobs.';
+  String get description => commandName == 'profile:job:aot'
+      ? 'Alias for profile:job; run repeated AOT profiling trials.'
+      : 'Run repeated AOT profiling trials for Stem jobs.';
 
   @override
   Future<int> run() async {

--- a/repodoc/lib/src/commands/profile_vm_command.dart
+++ b/repodoc/lib/src/commands/profile_vm_command.dart
@@ -33,7 +33,7 @@ final class ProfileVmCommand extends Command<int> {
   Future<int> run() async {
     final catalog = WorkspaceCatalog.load();
     final root = catalog.root;
-    final serviceInfo = _string('service-info');
+    final serviceInfo = _required('service-info');
     await File(p.join(root.path, serviceInfo)).parent.create(recursive: true);
     stdout.writeln('VM service details will be written to $serviceInfo');
     stdout.writeln(
@@ -50,19 +50,19 @@ final class ProfileVmCommand extends Command<int> {
         '--write-service-info=$serviceInfo',
         'benchmark/stem_job_profile.dart',
         '--tasks',
-        _string('tasks'),
+        _required('tasks'),
         '--warmup',
-        _string('warmup'),
+        _required('warmup'),
         '--concurrency',
-        _string('concurrency'),
+        _required('concurrency'),
         '--mode',
-        _string('mode'),
+        _required('mode'),
         '--workload',
-        _string('workload'),
+        _required('workload'),
         '--work-units',
-        _string('work-units'),
+        _required('work-units'),
         '--hold-seconds',
-        _string('hold-seconds'),
+        _required('hold-seconds'),
       ],
       workingDirectory: root,
       label: 'VM job profile',
@@ -70,5 +70,11 @@ final class ProfileVmCommand extends Command<int> {
     return 0;
   }
 
-  String _string(String name) => argResults?[name] as String? ?? '';
+  String _required(String name) {
+    final value = argResults?[name];
+    if (value is! String || value.trim().isEmpty) {
+      throw ArgumentError('Missing profile option: --$name');
+    }
+    return value;
+  }
 }

--- a/repodoc/lib/src/commands/quality_command.dart
+++ b/repodoc/lib/src/commands/quality_command.dart
@@ -1,6 +1,7 @@
 import 'package:artisanal/args.dart';
 
 import '../infrastructure/process_runner.dart';
+import '../infrastructure/toolchain.dart';
 import '../infrastructure/workspace.dart';
 
 final class QualityDartCommand extends Command<int> {
@@ -41,8 +42,21 @@ final class QualityDartCommand extends Command<int> {
       throw StateError('No packages matched the requested quality scope.');
     }
 
-    final runner = ProcessRunner(environment: catalog.processEnvironment);
+    final pubTool = await Toolchain.pubTool();
+    final environment = catalog.processEnvironment;
+    if (pubTool == 'flutter') {
+      environment['FLUTTER_ROOT'] = await Toolchain.flutterRoot();
+    }
+    final runner = ProcessRunner(environment: environment);
     for (final package in packages) {
+      if (!package.workspaceMember) {
+        await runner.run(
+          pubTool,
+          ['pub', 'get'],
+          workingDirectory: package.directory,
+          label: 'resolve ${package.relativePath}',
+        );
+      }
       final formatTargets = <String>[
         if (package.hasLib) 'lib',
         if (package.hasTest) 'test',

--- a/repodoc/lib/src/commands/standalone_command.dart
+++ b/repodoc/lib/src/commands/standalone_command.dart
@@ -67,14 +67,26 @@ final class StandaloneDartCommand extends Command<int> {
         final output = Directory(
           p.join(staging.path, p.basename(package.relativePath)),
         )..createSync(recursive: true);
-        final stagedPath = (await runner.capture('dart', [
+        final stagedOutput = await runner.capture('dart', [
           'run',
           'tool/stage_workspace.dart',
           '--package',
           package.relativePath,
           '--output',
           output.path,
-        ], workingDirectory: root)).trim().split('\n').last;
+        ], workingDirectory: root);
+        final stagedLines = stagedOutput
+            .split('\n')
+            .map((line) => line.trim())
+            .where((line) => line.isNotEmpty)
+            .toList(growable: false);
+        final stagedPath = stagedLines.isEmpty ? null : stagedLines.last;
+        if (stagedPath == null || !Directory(stagedPath).existsSync()) {
+          throw StateError(
+            'Workspace staging did not return a valid directory for '
+            '${package.relativePath}.',
+          );
+        }
         await runner.run(
           pubTool,
           ['pub', 'get'],

--- a/repodoc/lib/src/commands/standalone_command.dart
+++ b/repodoc/lib/src/commands/standalone_command.dart
@@ -87,6 +87,9 @@ final class StandaloneDartCommand extends Command<int> {
             '${package.relativePath}.',
           );
         }
+        if (flutterOnly) {
+          _addFlutterToolchainOverride(Directory(stagedPath));
+        }
         await runner.run(
           pubTool,
           ['pub', 'get'],
@@ -98,5 +101,23 @@ final class StandaloneDartCommand extends Command<int> {
       await staging.delete(recursive: true);
     }
     return 0;
+  }
+
+  void _addFlutterToolchainOverride(Directory stagedPackage) {
+    // Flutter 3.47.1 pins test_api 0.7.12, while Ormed 0.3.0's analyzer
+    // toolchain resolves test 1.31.2, which requires test_api 0.7.13. The
+    // workspace root carries this development-only override; preserve it in
+    // the isolated Flutter resolution without publishing it in the package.
+    final overridesFile = File(
+      p.join(stagedPackage.path, 'pubspec_overrides.yaml'),
+    );
+    final existing = overridesFile.existsSync()
+        ? overridesFile.readAsStringSync()
+        : 'dependency_overrides:\n';
+    if (RegExp(r'^\s+test_api:', multiLine: true).hasMatch(existing)) {
+      return;
+    }
+    final separator = existing.endsWith('\n') ? '' : '\n';
+    overridesFile.writeAsStringSync('$existing$separator  test_api: 0.7.13\n');
   }
 }

--- a/repodoc/lib/src/commands/test_commands.dart
+++ b/repodoc/lib/src/commands/test_commands.dart
@@ -187,26 +187,15 @@ final class TestOrchestrator {
       label: 'resolve root workspace',
     );
 
-    final dashboard = catalog.select(
-      requestedPaths: const ['packages/dashboard'],
-      includeFlutter: true,
-    );
-    if (dashboard.isNotEmpty) {
-      await runner.run(
-        pubTool,
-        ['pub', 'get'],
-        workingDirectory: dashboard.single.directory,
-        environment: resolvedEnvironment,
-        label: 'resolve packages/dashboard',
-      );
-    }
+    // The dashboard is an experimental companion outside the workspace. Its
+    // Routed dependency graph is validated by the explicit dashboard tasks,
+    // not by the core Stem gate.
     return resolvedEnvironment;
   }
 
   Future<void> runNoEnvironment([Map<String, String>? environment]) async {
     await _runDartPackages(
       const [
-        'packages/dashboard',
         'packages/stem',
         'packages/stem_adapter_tests',
         'packages/stem_builder',

--- a/repodoc/lib/src/infrastructure/workspace.dart
+++ b/repodoc/lib/src/infrastructure/workspace.dart
@@ -88,7 +88,16 @@ final class WorkspaceCatalog {
   }) {
     final requested = requestedPaths == null || requestedPaths.isEmpty
         ? null
-        : requestedPaths.toSet();
+        : requestedPaths.map(_normalizeRequestedPath).toSet();
+    if (requested != null) {
+      final known = packages.map((package) => package.relativePath).toSet();
+      final unknown = requested.difference(known);
+      if (unknown.isNotEmpty) {
+        throw ArgumentError(
+          'Unknown workspace package path(s): ${unknown.join(', ')}',
+        );
+      }
+    }
     return packages
         .where((package) => !workspaceOnly || package.workspaceMember)
         .where((package) => includeFlutter || !package.isFlutter)
@@ -98,6 +107,8 @@ final class WorkspaceCatalog {
         )
         .toList(growable: false);
   }
+
+  String _normalizeRequestedPath(String value) => p.normalize(value.trim());
 }
 
 final class WorkspacePackage {

--- a/repodoc/lib/src/repodoc_runner.dart
+++ b/repodoc/lib/src/repodoc_runner.dart
@@ -47,9 +47,11 @@ CommandRunner<int> createRepodocRunner() {
 Future<int> runRepodoc(List<String> arguments) async {
   final runner = createRepodocRunner();
   try {
-    return await runner.run(arguments) ?? 0;
-  } catch (error) {
+    final result = await runner.run(arguments);
+    return result ?? exitCode;
+  } catch (error, stackTrace) {
     stderr.writeln(error);
+    stderr.writeln(stackTrace);
     return 1;
   }
 }

--- a/repodoc/lib/src/repodoc_runner.dart
+++ b/repodoc/lib/src/repodoc_runner.dart
@@ -46,9 +46,19 @@ CommandRunner<int> createRepodocRunner() {
 
 Future<int> runRepodoc(List<String> arguments) async {
   final runner = createRepodocRunner();
+  exitCode = 0;
   try {
     final result = await runner.run(arguments);
-    return result ?? exitCode;
+    if (result != null) return result;
+    if (exitCode == runner.usageExitCode) {
+      stderr.writeln(runner.usage);
+    }
+    return exitCode;
+  } on UsageException catch (error) {
+    stderr.writeln(error.message);
+    stderr.writeln(error.usage);
+    exitCode = runner.usageExitCode;
+    return exitCode;
   } catch (error, stackTrace) {
     stderr.writeln(error);
     stderr.writeln(stackTrace);

--- a/repodoc/pubspec.yaml
+++ b/repodoc/pubspec.yaml
@@ -1,22 +1,22 @@
 name: repodoc
 description: Central repository maintenance and diagnostics for Stem.
 publish_to: none
-version: 0.1.0
+version: 0.2.0
 resolution: workspace
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   artisanal: ^0.5.0
   path: ^1.9.1
-  stem: ^0.3.0
-  stem_memory: ^0.2.0
-  stem_postgres: ^0.2.0
-  stem_redis: ^0.2.0
-  stem_sqlite: ^0.2.0
+  stem: ^0.4.0
+  stem_memory: ^0.3.0
+  stem_postgres: ^0.3.0
+  stem_redis: ^0.3.0
+  stem_sqlite: ^0.3.0
   yaml: ^3.1.3
 
 dev_dependencies:
-  test: ^1.31.0
+  test: ^1.31.2
   very_good_analysis: ^10.0.0

--- a/tool/profile_job.dart
+++ b/tool/profile_job.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import '../benchmark/benchmark_display.dart';
+import '../benchmark/profile_support.dart';
 
 /// Compiles and repeats the deterministic job profile as an AOT executable.
 ///
@@ -9,13 +10,13 @@ import '../benchmark/benchmark_display.dart';
 /// allocator state, and worker shutdown cannot leak from one trial into the
 /// next trial, making the summary more useful than a single long-lived run.
 Future<void> main(List<String> args) async {
-  final repetitions = _intOption(args, '--repetitions', 5);
+  final repetitions = profileIntOption(args, '--repetitions', 5);
   if (repetitions <= 0) {
     throw ArgumentError.value(repetitions, '--repetitions');
   }
 
   final outputPath =
-      _stringOption(args, '--output') ??
+      profileStringOption(args, '--output') ??
       'build/stem-profile/aot-${_timestamp()}.json';
   final jsonOutput = args.contains('--json');
   final childArgs = _childArgs(args);
@@ -46,7 +47,7 @@ Future<void> main(List<String> args) async {
       'operatingSystem': Platform.operatingSystem,
       'processorCount': Platform.numberOfProcessors,
       'repetitions': repetitions,
-      'scenario': _scenario(childArgs),
+      'scenario': _scenarioFromSample(samples.first),
       'samples': samples,
       'summary': _summaries(samples),
     };
@@ -109,10 +110,22 @@ Future<Map<String, Object?>> _runSample(
 }
 
 List<String> _childArgs(List<String> args) {
+  const childOptions = {
+    '--tasks',
+    '--warmup',
+    '--concurrency',
+    '--mode',
+    '--workload',
+    '--work-units',
+    '--hold-seconds',
+  };
   final child = <String>[];
   for (var index = 0; index < args.length; index++) {
     final arg = args[index];
     if (arg == '--repetitions' || arg == '--output') {
+      if (index + 1 >= args.length || args[index + 1].startsWith('--')) {
+        throw ArgumentError('Missing value for $arg.');
+      }
       index += 1;
       continue;
     }
@@ -121,19 +134,32 @@ List<String> _childArgs(List<String> args) {
         arg.startsWith('--output=')) {
       continue;
     }
-    child.add(arg);
+    if (arg.startsWith('--')) {
+      final option = arg.split('=').first;
+      if (!childOptions.contains(option)) {
+        throw ArgumentError('Unknown profile option: $arg.');
+      }
+      child.add(arg);
+      if (!arg.contains('=') &&
+          index + 1 < args.length &&
+          !args[index + 1].startsWith('--')) {
+        child.add(args[++index]);
+      }
+      continue;
+    }
+    throw ArgumentError('Unexpected profile argument: $arg.');
   }
   return child;
 }
 
-Map<String, Object?> _scenario(List<String> args) {
+Map<String, Object?> _scenarioFromSample(Map<String, Object?> sample) {
   return {
-    'tasks': _intOption(args, '--tasks', 5000),
-    'warmup': _intOption(args, '--warmup', 500),
-    'concurrency': _intOption(args, '--concurrency', 4),
-    'mode': _stringOption(args, '--mode') ?? 'isolate',
-    'workload': _stringOption(args, '--workload') ?? 'noop',
-    'workUnits': _intOption(args, '--work-units', 100),
+    'tasks': sample['tasks'],
+    'warmup': sample['warmupTasks'],
+    'concurrency': sample['concurrency'],
+    'mode': sample['executionMode'],
+    'workload': sample['workload'],
+    'workUnits': sample['workUnits'],
   };
 }
 
@@ -176,16 +202,11 @@ Map<String, Object?> _statistics(List<double> values) {
   return {
     'count': sorted.length,
     'min': sorted.first,
-    'median': _percentile(sorted, 0.5),
-    'p95': _percentile(sorted, 0.95),
+    'median': profilePercentile(sorted, 0.5),
+    'p95': profilePercentile(sorted, 0.95),
     'max': sorted.last,
     'mean': sum / sorted.length,
   };
-}
-
-double _percentile(List<double> sorted, double percentile) {
-  final index = ((sorted.length - 1) * percentile).round();
-  return sorted[index.clamp(0, sorted.length - 1).toInt()];
 }
 
 Future<String?> _gitSha() async {
@@ -196,18 +217,4 @@ Future<String?> _gitSha() async {
 
 String _timestamp() {
   return DateTime.now().toUtc().toIso8601String().replaceAll(':', '-');
-}
-
-String? _stringOption(List<String> args, String name) {
-  final prefix = '$name=';
-  for (final arg in args) {
-    if (arg.startsWith(prefix)) return arg.substring(prefix.length);
-  }
-  final index = args.indexOf(name);
-  if (index == -1 || index + 1 >= args.length) return null;
-  return args[index + 1];
-}
-
-int _intOption(List<String> args, String name, int fallback) {
-  return int.tryParse(_stringOption(args, name) ?? '') ?? fallback;
 }

--- a/tool/profile_job.dart
+++ b/tool/profile_job.dart
@@ -129,9 +129,13 @@ List<String> _childArgs(List<String> args) {
       index += 1;
       continue;
     }
-    if (arg == '--json' ||
-        arg.startsWith('--repetitions=') ||
-        arg.startsWith('--output=')) {
+    if (arg == '--json') {
+      continue;
+    }
+    if (arg.startsWith('--repetitions=') || arg.startsWith('--output=')) {
+      if (arg.endsWith('=')) {
+        throw ArgumentError('Missing value for ${arg.split('=').first}.');
+      }
       continue;
     }
     if (arg.startsWith('--')) {
@@ -139,12 +143,18 @@ List<String> _childArgs(List<String> args) {
       if (!childOptions.contains(option)) {
         throw ArgumentError('Unknown profile option: $arg.');
       }
-      child.add(arg);
-      if (!arg.contains('=') &&
-          index + 1 < args.length &&
-          !args[index + 1].startsWith('--')) {
-        child.add(args[++index]);
+      if (arg.contains('=')) {
+        if (arg.endsWith('=')) {
+          throw ArgumentError('Missing value for $option.');
+        }
+        child.add(arg);
+        continue;
       }
+      if (index + 1 >= args.length || args[index + 1].startsWith('--')) {
+        throw ArgumentError('Missing value for $arg.');
+      }
+      child.add(arg);
+      child.add(args[++index]);
       continue;
     }
     throw ArgumentError('Unexpected profile argument: $arg.');

--- a/tool/publish.dart
+++ b/tool/publish.dart
@@ -279,12 +279,16 @@ Future<void> _validatePackage(
   _Package package, {
   required bool checkGenerated,
 }) async {
-  await _run('dart', [
-    'format',
-    'lib',
-    'test',
-    '--set-exit-if-changed',
-  ], package);
+  if (checkGenerated && package.hasBuildRunner) {
+    await _run('dart', [
+      'run',
+      'build_runner',
+      'build',
+      '--delete-conflicting-outputs',
+    ], package);
+  }
+
+  await _run('dart', ['format', 'lib', 'test'], package);
   final executable = package.isFlutter ? 'flutter' : 'dart';
   await _run(executable, ['analyze', '--fatal-infos'], package);
   final testArguments = <String>['test', '--fail-fast'];
@@ -294,15 +298,10 @@ Future<void> _validatePackage(
   }
   await _run(executable, testArguments, package);
 
-  if (checkGenerated && package.hasBuildRunner) {
-    await _run('dart', [
-      'run',
-      'build_runner',
-      'build',
-      '--delete-conflicting-outputs',
-    ], package);
-    await _runGitDiffCheck(package.path);
-  }
+  // The formatter may normalize output emitted by a generator. Verify the
+  // final package tree instead of failing on the generator's intermediate
+  // formatting, while still refusing to release uncommitted source changes.
+  await _runGitDiffCheck(package.path);
 
   final changelog = File('${package.path}/CHANGELOG.md');
   if (!changelog.existsSync()) {


### PR DESCRIPTION
## Summary

Prepares the Stem workspace for the next coordinated package release.

- Raises the minimum Dart SDK to 3.12.
- Bumps Stem to 0.4.0 and the adapter/package train to the corresponding 0.3.x releases.
- Updates Ormed to 0.3.x and `ormed_sqlite` to 0.4.x.
- Keeps generated Postgres and SQLite model registries current with Ormed 0.3.
- Updates analyzer 14 constructor diagnostics across the affected packages.

## OpenTelemetry

- Upgrades Dartastic OpenTelemetry and its API to 0.10.0.
- Uses the public `OTelAPI.context()` API.
- Delegates task-header propagation to the configured global text-map propagator.
- Honors `OTEL_PROPAGATORS`, including `none`.
- Uses the SDK tracer enabled/no-processor fast path.

## Ormed decision

Ormed 0.3 provides a simpler codegen-free application facade, but Stem internals still depend on generated typed model registries and repositories. This change updates the supported dependency line without performing a risky internal database rewrite.

## Validation

- `flutter pub get`
- `dart analyze --fatal-infos`
- Dart formatting and `git diff --check`
- OpenTelemetry tracing tests
- Flutter analysis and tests
- Flutter SQLite package tests
- Postgres/SQLite build-runner generation with no remaining generated drift
- Release dependency-order planning via `tool/publish.dart`

The local Dart test runner remains environment-limited by a missing `frontend_server.dart.snapshot`; the focused Flutter suites and analyzer pass.

This updates existing PR #27; no duplicate PR was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified commands for quality checks, coverage, testing, benchmarking, profiling, and standalone dependency resolution.
  * Added benchmark support for memory, SQLite, PostgreSQL, and Redis with improved reporting and profiling options.
  * Added automated health checks and pull request summary workflows.

* **Improvements**
  * Updated the minimum supported Dart SDK to 3.12.
  * Improved benchmark documentation, CI execution, and failure reporting.
  * Improved OpenTelemetry context propagation and tracing efficiency.
  * Strengthened Redis TLS test security and SQLite timing reliability.
  * Updated package releases and changelogs for the latest compatibility versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->